### PR TITLE
Fix image tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tailscale-gnome-qs
 
-[<img alt="" height="100" src="https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true">]
+<img alt="" height="100" src="https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true">
 
 ##### BUILD (UBUNTU)
 


### PR DESCRIPTION
Before
<img width="697" height="434" alt="image" src="https://github.com/user-attachments/assets/5b337a06-e397-4531-85c3-9ce8de298456" />
Now
<img width="697" height="295" alt="image" src="https://github.com/user-attachments/assets/6ff41efe-bb42-484b-aa18-7823c3af6cf9" />
