### PR TITLE
regression: Re-enable ip-copied osd

### DIFF
--- a/tailscale-gnome-qs@tailscale-qs.github.io/extension.js
+++ b/tailscale-gnome-qs@tailscale-qs.github.io/extension.js
@@ -297,7 +297,7 @@ const TailscaleMenuToggle = GObject.registerClass(
 
             St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, node.ips[0]);
             St.Clipboard.get_default().set_text(St.ClipboardType.PRIMARY, node.ips[0]);
-            Main.osdWindowManager.showOne(-1, icon, _("IP address has been copied to the clipboard"));
+            Main.osdWindowManager.showAll(icon, _("IP address has been copied to the clipboard"));
             return true;
           };
 


### PR DESCRIPTION
The plugin's functionality would allow a user to long-click a node in the menu to copy its corresponding ip-address to the clipboard. As part of that functionality, there would be a OSD pop-up to indicate the action performed. Unfortunately, this functionality was broken in subsequent fixes. This change fixes the expected behavior.

The result after long-click with this fix:
<img width="2560" height="1600" alt="Screenshot From 2026-03-31 13-51-05" src="https://github.com/user-attachments/assets/4c71f2d3-72d0-4ad8-846e-c60e92254e22" />
