### PR TITLE
refactor: Run linter to cleanup codebase

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -23,5 +23,5 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: tailscale@joaophi.github.com.zip
-        path: tailscale@joaophi.github.com.zip
+        name: tailscale-gnome-qs@tailscale-qs.github.zip
+        path: tailscale-gnome-qs@tailscale-qs.github.zip

--- a/.github/workflows/reviewdog-eslint.yml
+++ b/.github/workflows/reviewdog-eslint.yml
@@ -1,0 +1,19 @@
+name: reviewdog eslint pr
+on: [pull_request, workflow_dispatch]
+jobs:
+  eslint:
+    name: runner / eslint
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: write
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: reviewdog/action-eslint@2fee6dd72a5419ff4113f694e2068d2a03bb35dd # v1.33.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          eslint_flags: "tailscale-gnome-qs@tailscale-qs.github.io/"
+          fail_level: warning

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 *.mo
+node_modules/

--- a/ambient.d.ts
+++ b/ambient.d.ts
@@ -1,0 +1,4 @@
+import "@girs/gjs";
+import "@girs/gjs/dom";
+import "@girs/gnome-shell/ambient";
+import "@girs/gnome-shell/extensions/global";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CC0-1.0
+// SPDX-FileCopyrightText: No rights reserved
+
+import {defineConfig} from '@eslint/config-helpers';
+import gnome from 'eslint-config-gnome';
+
+export default defineConfig([
+    gnome.configs.recommended,
+    gnome.configs.jsdoc,
+    {
+        rules: {
+            camelcase: ['error', {
+                properties: 'never',
+            }],
+            'consistent-return': 'error',
+            'eqeqeq': ['error', 'smart'],
+            'key-spacing': ['error', {
+                mode: 'minimum',
+                beforeColon: false,
+                afterColon: true,
+            }],
+            'prefer-arrow-callback': 'error',
+            'prefer-const': ['error', {
+                destructuring: 'all',
+            }],
+            'jsdoc/require-param-description': 'off',
+            'jsdoc/require-jsdoc': ['error', {
+                exemptEmptyFunctions: true,
+                publicOnly: {
+                    esm: true,
+                },
+            }],
+        },
+        languageOptions: {
+            globals: {
+                global: 'readonly',
+            },
+        },
+    },
+]);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "tailscale-gnome-qs",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "[![Get it on GNOME Extensions](https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true)](https://extensions.gnome.org/extension/9193/tailscale-qs/)",
+  "main": "eslint.config.js",
+  "scripts": {
+    "lint": "eslint tailscale-gnome-qs@tailscale-qs.github.io/",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailscale-qs/tailscale-gnome-qs.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/tailscale-qs/tailscale-gnome-qs/issues"
+  },
+  "homepage": "https://github.com/tailscale-qs/tailscale-gnome-qs#readme",
+  "devDependencies": {
+    "@eslint/config-helpers": "^0.5.3",
+    "@eslint/js": "9.39.4",
+    "@girs/gjs": "4.0.0-beta.44",
+    "@girs/gnome-shell": "^49.1.0",
+    "@stylistic/eslint-plugin": "^5.10.0",
+    "eslint": "^9.39.4",
+    "eslint-config-gnome": "git+https://gitlab.gnome.org/World/javascript/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51",
+    "eslint-formatter-junit": "^9.0.1",
+    "eslint-plugin-jsdoc": "^48.11.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1824 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@eslint/config-helpers':
+        specifier: ^0.5.3
+        version: 0.5.3
+      '@eslint/js':
+        specifier: 9.39.4
+        version: 9.39.4
+      '@girs/gjs':
+        specifier: 4.0.0-beta.44
+        version: 4.0.0-beta.44
+      '@girs/gnome-shell':
+        specifier: ^49.1.0
+        version: 49.1.0
+      '@stylistic/eslint-plugin':
+        specifier: ^5.10.0
+        version: 5.10.0(eslint@9.39.4)
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4
+      eslint-config-gnome:
+        specifier: git+https://gitlab.gnome.org/World/javascript/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51
+        version: git+https://gitlab.gnome.org/World/javascript/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51(eslint@9.39.4)
+      eslint-formatter-junit:
+        specifier: ^9.0.1
+        version: 9.0.1
+      eslint-plugin-jsdoc:
+        specifier: ^48.11.0
+        version: 48.11.0(eslint@9.39.4)
+
+packages:
+
+  '@es-joy/jsdoccomment@0.46.0':
+    resolution: {integrity: sha512-C3Axuq1xd/9VqFZpW4YAzOx5O9q/LP46uIQy/iNDpHG3fmPa6TBtvfglMCs3RBiBxAIi0Go97r8+jvTt55XMyQ==}
+    engines: {node: '>=16'}
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.2.3':
+    resolution: {integrity: sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.5.3':
+    resolution: {integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@1.1.1':
+    resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@girs/accountsservice-1.0@1.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-6QzytM5dztmMynF2bxN73EuNK9ArMFxkP2L8wUC7IH45zBeBOfYcqL85BFh2PmkGmqRk+Rli5EFR8dAkx3Ig5Q==}
+
+  '@girs/adw-1@1.9.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-AaP8nDnUQkB7AUiOvOXXyXbjFC/L8Uh8MwqDD/NZKpIGKYwgE8hfuLyPW1d/K10wabLq4pgO19QJiTpr6hKyhg==}
+
+  '@girs/atk-1.0@2.58.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-rfLlLlAecHE1uAqK81DHZT27E1nVwN/pAHtgbgDUcu70UdHoCYAsQymLjk/tuDcTX0Lwp6U9x6w+GHG1sbYlQA==}
+
+  '@girs/atk-1.0@2.60.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-BnFh7uuHyoByNRLSVrJfpxrPFC6foOc0xy+P8eJivQ6z0v6LsFNwd5dLxqqJAP0cfO86qFNa+lhFzKyTLVuWRQ==}
+
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-VJa0vw9teZjCydDzWIcbNBwT37MSej52rqwBuQ/ir7+72+7dpzeudkNOOif1nDIulGu+RLAy4cgWbguQhsUH/Q==}
+
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-luqUsMf2cPphDc4lb8IHcw0bX8eGa4g0aQypZJypAeIs9eyHfEDHWKhLgp4I0HaQvaevbd3QBosaH7UhkArL1A==}
+
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-mzBnBLJjDyGxNvSJkKu2CCrQ3GfyeXuwgAaPBcGvf2FqCSeIHlFdaGCqijWHMd86Th7XpL6k3/lpzKVewuo3iw==}
+
+  '@girs/clutter-17@17.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-ILEINU3SiPtc1JVsNYzE6fCasBZWxSbK1Q7jPWSVh3195ISSxGdzHJYLke4li7ctsnXszSxHAvenf4nDqegnzg==}
+
+  '@girs/cogl-17@17.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-7p/fSI0tCu3lPZc0QYSai3OY/qA0xdOxTNStLa2zO3zzJy5R+w1/QcU/UNx9fADRWHvY8+p/QCOzfSWbAav/pw==}
+
+  '@girs/cogl-2.0@2.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-eIvTpvXDLNUEhdAPDOoSrQGjJTcVvyCvCUU0rKEOdZBOFrTYCcPfALWEvx6z7/NYC1SrFlhQruZm8epm0N36Xw==}
+
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==}
+
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-vS+etsSesMQZNH8Sei81fmkWcgYzjLDbddSPIZaCw2nJ1TIu8eC/CTW46bBk0JGgOaQwL3DxuE0V+BdyhQwIyQ==}
+
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-AqKiyZAmFxIyrpw4bz1q+dqMM1INlmi4mTldrCV4riQhxS/MksgygQ0YatXw9gwW8N/jR2B1GK7y8L1hLvzC+Q==}
+
+  '@girs/gck-2@4.4.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-jTocnq1nJ0FFPqzQ53HX5tpopNmAyzVu8GFVmSPSOfcoqfe0Im9AmyGIBZIvievPpVvJDbEnUimM651bOVzh+Q==}
+
+  '@girs/gcr-4@4.4.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-EPiGPdvkmY25VZ4nV1bdVM+oCrEU23Ome0hqUJJMB1y2s0kfQ3tPW9/tZMlz9gWEdpT8TAQ7cPb08aqK9gYkAQ==}
+
+  '@girs/gdesktopenums-3.0@3.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-OnQZHM7HodJQo0xgTWVX6FhjSCcyhfrAJp2SN26Ab0EH06wYOC8BR2D6/qPHO/b4CFG7Ugstwiau1lro0+Df1Q==}
+
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-hk6SG4pCcezKp2VNxJc0TC1gkZe3C8shD8sRQ3bUGyWl/9581WM2/8UU+W6fOf3SwXA1hquN6d3SjKbqkFNRKg==}
+
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-4O5Yqk1QSKUqaRn7402XtkGFwg/7SMoGof0Xe/JiqnjF7oDav2giRUoDKx4uXKnfQm+6NA69b0meGEXr8yJJYA==}
+
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-CDovRK3h3dGUZB4ESflx35GthhgRSThD9ob4ywSjVf0SuuQBdPMgZtcpO+gGIn+tIBhikTXOp3snUeaRPhnFFw==}
+
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==}
+
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-ImVsfgs4OdJnWqZm1ugB+WcpySf2wNtY99nUBm+/YpCLeIyrl+NRbft+ymom6CTim83f3XzwaOCDEwE5azj42w==}
+
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-NkOf4Iny7VxfPFo2kHWf5l7DoMrHH5upqK+3Z+E9yXWyWJdPx6bBvScjMpm9lWPFOGhivSewCaKRP7JikHU/aA==}
+
+  '@girs/gdm-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-HuEmPwSXi/lUSw/G/6uWi0+phlhyW2/XsblghYlW/fDMoPhV5LvLx685fQO0LFzS3a6NXWczYsBH0OHoVvhQYg==}
+
+  '@girs/gio-2.0@2.86.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-hKCyDEqSIgqcZeFf63KNrUnrYtAuJ0yfIypbdLgNEMbJBPQ/e3ZiwzWa7i3OPCh52Cnl9qYRdj8MSbZndpyZiQ==}
+
+  '@girs/gio-2.0@2.86.4-4.0.0-beta.40':
+    resolution: {integrity: sha512-TTAEE/2nCAkx01hID4n8f0ByiFJ0QwGJcY8QYmom19QXmlIWCLF/GWLeXi/7ZyKJOtChSFk8IJglS0O6zC1spw==}
+
+  '@girs/gio-2.0@2.88.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-NQGN7Zjy42GcHjhn6qfUHweG+pAZnfoRvsSEtWnU7mH/8LAwC/4/yVE00L6M4M6r4wApwclxfQVkhSn4vvz8qg==}
+
+  '@girs/giounix-2.0@2.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-/4hLNHjhME1rp+ynz1iLTuvONNyRfDLoJPzFA6qIBtqCwoDmik0WJ3OLTZHosWtRqkNYm/sZkaYCFFCrjFzcgQ==}
+
+  '@girs/gjs@4.0.0-beta.38':
+    resolution: {integrity: sha512-eI/9lfI1mQpXN8RsKiNRFWJso6LgQe9Eb+YxLAdKarD5fccvIRx3chsyIyhw5tYH7VvgaZkqm1c4GX7pDDokBQ==}
+
+  '@girs/gjs@4.0.0-beta.40':
+    resolution: {integrity: sha512-+gHGA5PJvEExpiPkpc3+DSjhWGmxHDb482h52FO64eo2EmHuLoeOKCoUJIY0PS80xOJWFRSO2dNFxZdD1bV6XA==}
+
+  '@girs/gjs@4.0.0-beta.44':
+    resolution: {integrity: sha512-VS+EeClZWYmplqNzDK9Ta5Je+sFOL6iFirYzDylWxQGeW8fdHcWGZX7RlXjuuTSkCNsRaAjWfd5DG/Yo5UkVGg==}
+
+  '@girs/gl-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-UowxYk+E1e1cePkZ9FW1OPmqoz6leXIrSF9iCoQlBlxw7/UlNq1KM2dJVsudhrNZGsHiylnqr7wFW5ce5ZSJjg==}
+
+  '@girs/glib-2.0@2.86.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-TFbrh5+Y3pb61synbhi37VrRzh0e+JQaRCzfGbe7oewUq0v7Sb8eSi2Fmj98r5tCizaRYptqgt6bxG7G5cFzVg==}
+
+  '@girs/glib-2.0@2.86.4-4.0.0-beta.40':
+    resolution: {integrity: sha512-DTvRmZlTVpYW+JI0zMN/dybhzoqJ/I3bx3txftSQgcxXl3mKnrSI6Qzv15VTyxQSpcnD3CBxpnfYT/+QrzU9QQ==}
+
+  '@girs/glib-2.0@2.88.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-mXOLTuC4P1DlYlzRPnLG+N6VAv8z3OgGbnSEP4r8U/+gA9nLCIrEuVlkqBdcBLiKyGfFz4diFYJVhHTGt7HQIQ==}
+
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-BmspJtwdBSfCJRZQMxn3gx6H9FNcoqCebFXK2UKknq18DIo8U2q4iN/jQBWPoLh2siK9LhCdL2egoyXteTy1NA==}
+
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-srPSbc/uespMNHR2o2Gg6OYeCprW42gADIXCujpMMWl5OfJzKU0mA+R8Z/D713tDq0xp1Lz2P7hprVznf1uF3A==}
+
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-ueMUwA8M/pCo8bdX+UUtzOUm5DaRkv7yvkg4624XGnlKUgJ15TgjIHages9ZcUtnCXNMLkSj2mJHPZbEtU5XpA==}
+
+  '@girs/gnome-shell@49.1.0':
+    resolution: {integrity: sha512-14Re6+DIrozWOErzW9fqvTAn0o9/1rMZuSDQ7BPIC+MYxmNmIlqzjo0kecbkXMN4ZY1zRpgfahbkiFwjJYZmfQ==}
+
+  '@girs/gnomebg-4.0@4.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-r5H5rV9g4NadZ6keOT4B1fuhYo5JoJBgTXpbuS8ZnaP8LDsCi8Abza5dcJVExm37U0XVM+AmTqqZ3nnbmk3e5Q==}
+
+  '@girs/gnomebluetooth-3.0@3.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-RkbgX0vKyCZ88h8M84HXK5jfojKdsjEUIWnwb7573bw5i1K4UEWX4Q4SsMh9pSZy8FqyZHEt01Itd7YWpIPPdA==}
+
+  '@girs/gnomedesktop-4.0@4.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-obLu2bg8MT6N6LGinu4NW6v8DGuNKe5/h4kXjrEKjIwvYV7P+ZlfwJyKyV2p5rUrXi9Woi1fLkigLyLFHAqoKw==}
+
+  '@girs/gobject-2.0@2.86.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-oYrm6Gb/tCQosMkN8Beu5jqGRkJ7LED4O1H1dKYOI4SnP1Ojb66A9ECy78yTO8piBtMopsbRODV81yKniVtKKA==}
+
+  '@girs/gobject-2.0@2.86.4-4.0.0-beta.40':
+    resolution: {integrity: sha512-coS5607duUekhRfl2GDC9Gt3WcgAtTNEDL0efrRBBOuORjvBrIGiGJJXB9cX4jYQ7c9FITUMVLTd+a0MMRAaXA==}
+
+  '@girs/gobject-2.0@2.88.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-mG7uCfw4QB+gi9WXGYZ6y5x+lKeGJTnPeM+hWiCkZBgRMpIrMH1LsyVqYJ5tX/a75w6x2zDj/OTI85igDhwpyg==}
+
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==}
+
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-0ReJbd31inyIE7Q96I4ED1uj6ssmfl1iB4xc6eakac95FZK/uZSC6uBtBLfA/tmnkgRb7ChQgK/ZGbb8sx4tHQ==}
+
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-jnI+LYVF1ciX45x8fEu30gSV3zf0JaVOz3hutRm9h2cwomNtqzhUVC7r68zIDiA3faP7VT7cQR0ghWHzWOnoIA==}
+
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-BfYpVfmKjD7Tq58W5p9fcU6Mvg3QcNRjJ1oQn05d/Xk1rjQmsk6tkcTkK3i/KIOhA9eVadQsMlFFWuN0KBE5Dw==}
+
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-hSNHG+E6O736vLgGtMcG50iiSoK/tRIVdsJ55H/AqyRCL2HzCzUIAQ7VTqsCgDGGs0N2P8i6Oq0FAZ7+4j/3IQ==}
+
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-WPvdP3K7Km63trbbTkvkX7VNFQdkRq47smjpGPWmDz/g4qNyP298szsq1UTuNwQfVvACBbbKqBjXIwLCakbCAw==}
+
+  '@girs/gtk-4.0@4.20.1-4.0.0-beta.38':
+    resolution: {integrity: sha512-lNujJDta1YK3/9Inp5HrtF/JOMN5EmD+3U7diRTyWNzc2KdaN2jO2mk90taaGK28xhoCC+VESkFkQAgFTwZXWw==}
+
+  '@girs/gtk-4.0@4.20.3-4.0.0-beta.40':
+    resolution: {integrity: sha512-rdAkZpt6IvyF8dvNsvC1cU8beQl1LesH0ZzpYArF0kg5KnKGDOqVGAAFjcz4QOHQ3LRiWJ47S5VT4n/TkCG76w==}
+
+  '@girs/gtk-4.0@4.22.1-4.0.0-beta.44':
+    resolution: {integrity: sha512-Im4/deI027H8yRCZCj0zZQuLkyva+mjEFPxN2mR+LaI9AM4PPrXO5d2JB7A0XBB1Mm2tomKq5Mn64mZmP5HbWQ==}
+
+  '@girs/gvc-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-3rJjOPOEofBXsmzOaY+3nDPN0X1SPxZhFEc43ukR+x0eCiIA73RKPbGNOM6eUk8dKg87vnlfz0z2ysnBOsa1/g==}
+
+  '@girs/harfbuzz-0.0@11.5.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==}
+
+  '@girs/harfbuzz-0.0@11.5.1-4.0.0-beta.40':
+    resolution: {integrity: sha512-cwR4WHJ9LtnvvXFUnkiFtWdInKvhlQUr3bQHmHiJxCjloQHHMNVA7CsrMDL/tRD9WoU77rQF6dB+uqSlRKT1zQ==}
+
+  '@girs/harfbuzz-0.0@12.3.2-4.0.0-beta.44':
+    resolution: {integrity: sha512-5x2h5ETvS4mdz1XrS2hwRC/jw8oaCm28fpE4NcM3hSZ1iXQetJDkdhG0xHsID/Sk8cjBlcmT3+rV4kSvrHooMg==}
+
+  '@girs/meta-17@17.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-wQArnoWtMskfZGzF64CZvpIhocjNwp2aOFr2xDxtphvXTGgqaId7AALLDDCQMSUOLHA+amqaEmKZFi44FsBx3w==}
+
+  '@girs/mtk-17@17.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-N5KAS38Xoya9isapXxeNV+WHoyfp2tBtr8Vih40Tt+rGE/Ud+mz4stDGtL6LDU5S7tD2NNHMdySkOmpiSHr4Iw==}
+
+  '@girs/nm-1.0@1.56.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-77eRM4wMb3dGRSdAVA/vI3wJq+IKUL+L4yrag+ueYYAH8jEW/5YLqCWvGcpKpIjw6BYswpbwYigM1dtb4w+1ug==}
+
+  '@girs/pango-1.0@1.57.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==}
+
+  '@girs/pango-1.0@1.57.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-H8COoSffShFRilpCh9JQ6Lafd/WG+hPRKNkruvfmLAEcnIDnPDIS79BO3OOJz6E+QWqY9mwQIjqjjPwFcasuzA==}
+
+  '@girs/pango-1.0@1.57.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-p+BPQ8fn5u+1x+UWPjyaeZcF0pb8DRZv+1rKtMQdqBGRIvPhhwJ8QO9D2RiNZXWuacNOuwKaKkX8V/J7kMjuoA==}
+
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.38':
+    resolution: {integrity: sha512-BY4rEgQW0H1c/24v+FGBjSZgZ6rk2Y4+ka9/WldUs74N1ZOh6nS4lHKUyy0antylQ7x0Fnw5UHgN0PbpdjkGuQ==}
+
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.40':
+    resolution: {integrity: sha512-CFvAGWXWN/Ui469met+Q39Tmyn910Y6g+pBxWC60q5T1F9jck7qjehn1/Jo6D7R/n2Bh1FVyjYK3JhIwIMGOyw==}
+
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-jGZ+055hClZO36YJ+u+NzwmHNFtPrMaoaOroKC0ZWf5hzacN1kYH4fA2lu0IkiTx4VB/GWQxNddXJy8oXjrx6g==}
+
+  '@girs/polkit-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-k1p5IPKnpcZg4l2wFOtw5mcdNTF+9vi8PsSw+F/6rcyY2ISuo/fPeTeRezX7ie9Nf+1vXt5vbtKrOQNOzc6LXg==}
+
+  '@girs/polkitagent-1.0@1.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-d3itR4MHtMQ9Vz6tD9c9tlqlzT+oR/lPPoVRWAWBzXjbNUwJZSbUBSmc+lpJBSIqyQLzbif6SIEQ3qX/7FgrjQ==}
+
+  '@girs/shell-17@17.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-LjmZOA+IG9fxvgh0Fs9fFfDc2bGbbWnlolZ+PBpI3ltf+WfOnfQwXhAF3D2+S7aLSf1e4wMiP2Ejd+TLuoQgJA==}
+
+  '@girs/shew-0@0.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-ZTt9GSWFGjIDyFmhY/t86pgqioUXkxSfPyXx6w3J4EltkcXySusMsrvG1YUn3faKmFKa5yyvEw2XVdQ3jZPQsw==}
+
+  '@girs/st-17@17.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-Hh09k8z3eWDTpxzMkTj1T4HCCGvW4JtKWo6Fr6TmEEwTypYeKFlhju2hkV0JT7ncWMxbiKuyAuqbCOfsGIfK6Q==}
+
+  '@girs/upowerglib-1.0@0.99.1-4.0.0-beta.40':
+    resolution: {integrity: sha512-J4+XAEIg1ZsGOId49KcIpAW/8ARzBudbSbFyO4FVCavA+1YZC5ENfbL+QEP4w2T1BkRSvdtIM2161zB4nL1prQ==}
+
+  '@girs/xfixes-4.0@4.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-NV6taygHvjQjTun/UedIyEpFAEksHfg8LuKqe6iJ2VKnv9V2KXin/lcPq7fwaJdC9JS424t9b/piiB/i7jJPeA==}
+
+  '@girs/xlib-2.0@2.0.0-4.0.0-beta.44':
+    resolution: {integrity: sha512-TnEfYxg2ks8D3RJ9sDspK3d4gLKjQZkb66oGlUKtnNnqUS0BUlsiOemwFD2sarWsGZ5Iqsgan6ZAWtajG8MRYQ==}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@pkgr/core@0.1.2':
+    resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@stylistic/eslint-plugin@5.10.0':
+    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@typescript-eslint/types@8.58.0':
+    resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comment-parser@1.4.1:
+    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
+    engines: {node: '>= 12.0.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-gnome@git+https://gitlab.gnome.org/World/javascript/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51:
+    resolution: {commit: c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51, repo: https://gitlab.gnome.org/World/javascript/eslint-config-gnome.git, type: git}
+    version: 1.0.0
+
+  eslint-formatter-junit@9.0.1:
+    resolution: {integrity: sha512-0MrNGXg2C46M/ImjWuClHSGKHBR0eSBPfYHqPgYmB0utq7Jog3YyLBmbshNvo/Ba/Al3zClPWdd6/jnxk2F+9Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-plugin-jsdoc@48.11.0:
+    resolution: {integrity: sha512-d12JHJDPNo7IFwTOAItCeJY1hcqoIxE0lHA8infQByLilQ9xkqrRa6laWCnsuCrf+8rUnvxXY1XuTbibRBNylA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsdoc-type-pratt-parser@4.0.0:
+    resolution: {integrity: sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==}
+    engines: {node: '>=12.0.0'}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-imports@2.2.1:
+    resolution: {integrity: sha512-OL/zLggRp8mFhKL0rNORUTR4yBYujK/uU+xZL+/0Rgm2QE4nLO9v8PzEweSJEbMGKmDRjJE4R3IMJlL2di4JeQ==}
+    engines: {node: '>= 18'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  slashes@3.0.12:
+    resolution: {integrity: sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  synckit@0.9.3:
+    resolution: {integrity: sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@es-joy/jsdoccomment@0.46.0':
+    dependencies:
+      comment-parser: 1.4.1
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 4.0.0
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.2.3': {}
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/config-helpers@0.5.3':
+    dependencies:
+      '@eslint/core': 1.1.1
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@1.1.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@girs/accountsservice-1.0@1.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/adw-1@1.9.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.40
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.40
+      '@girs/gtk-4.0': 4.20.3-4.0.0-beta.40
+      '@girs/harfbuzz-0.0': 11.5.1-4.0.0-beta.40
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.40
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.40
+
+  '@girs/atk-1.0@2.58.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/atk-1.0@2.60.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/clutter-17@17.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/atk-1.0': 2.60.0-4.0.0-beta.44
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/cogl-17': 17.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/mtk-17': 17.0.0-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+
+  '@girs/cogl-17@17.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/mtk-17': 17.0.0-4.0.0-beta.44
+
+  '@girs/cogl-2.0@2.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gck-2@4.4.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gcr-4@4.4.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gck-2': 4.4.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gdesktopenums-3.0@3.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/harfbuzz-0.0': 11.5.0-4.0.0-beta.38
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.38
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.38
+
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/harfbuzz-0.0': 11.5.1-4.0.0-beta.40
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.40
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.40
+
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gdm-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gio-2.0@2.86.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/gio-2.0@2.86.4-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/gio-2.0@2.88.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/giounix-2.0@2.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gjs@4.0.0-beta.38':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/gjs@4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/gjs@4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gl-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/glib-2.0@2.86.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/glib-2.0@2.86.4-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/glib-2.0@2.88.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gnome-shell@49.1.0':
+    dependencies:
+      '@girs/accountsservice-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/adw-1': 1.9.0-4.0.0-beta.40
+      '@girs/atk-1.0': 2.58.0-4.0.0-beta.38
+      '@girs/clutter-17': 17.0.0-4.0.0-beta.44
+      '@girs/cogl-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gcr-4': 4.4.0-4.0.0-beta.44
+      '@girs/gdm-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/giounix-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gnomebg-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gnomebluetooth-3.0': 3.0.0-4.0.0-beta.44
+      '@girs/gnomedesktop-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gtk-4.0': 4.20.1-4.0.0-beta.38
+      '@girs/gvc-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/meta-17': 17.0.0-4.0.0-beta.44
+      '@girs/mtk-17': 17.0.0-4.0.0-beta.44
+      '@girs/polkit-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/shell-17': 17.0.0-4.0.0-beta.44
+      '@girs/shew-0': 0.0.0-4.0.0-beta.44
+      '@girs/st-17': 17.0.0-4.0.0-beta.44
+      '@girs/upowerglib-1.0': 0.99.1-4.0.0-beta.40
+
+  '@girs/gnomebg-4.0@4.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.44
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gnomedesktop-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/gnomebluetooth-3.0@3.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gnomedesktop-4.0@4.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gobject-2.0@2.86.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/gobject-2.0@2.86.4-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/gobject-2.0@2.88.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.38
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/harfbuzz-0.0': 11.5.0-4.0.0-beta.38
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.38
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.38
+
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.40
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/harfbuzz-0.0': 11.5.1-4.0.0-beta.40
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.40
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.40
+
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/gtk-4.0@4.20.1-4.0.0-beta.38':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.38
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.38
+      '@girs/harfbuzz-0.0': 11.5.0-4.0.0-beta.38
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.38
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.38
+
+  '@girs/gtk-4.0@4.20.3-4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.40
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.40
+      '@girs/harfbuzz-0.0': 11.5.1-4.0.0-beta.40
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.40
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.40
+
+  '@girs/gtk-4.0@4.22.1-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/gvc-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/harfbuzz-0.0@11.5.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+
+  '@girs/harfbuzz-0.0@11.5.1-4.0.0-beta.40':
+    dependencies:
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/harfbuzz-0.0@12.3.2-4.0.0-beta.44':
+    dependencies:
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/meta-17@17.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/atk-1.0': 2.60.0-4.0.0-beta.44
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/clutter-17': 17.0.0-4.0.0-beta.44
+      '@girs/cogl-17': 17.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/mtk-17': 17.0.0-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/xfixes-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.44
+
+  '@girs/mtk-17@17.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/nm-1.0@1.56.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/pango-1.0@1.57.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/harfbuzz-0.0': 11.5.0-4.0.0-beta.38
+
+  '@girs/pango-1.0@1.57.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/harfbuzz-0.0': 11.5.1-4.0.0-beta.40
+
+  '@girs/pango-1.0@1.57.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.38':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.38
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gio-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gjs': 4.0.0-beta.38
+      '@girs/glib-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.38
+      '@girs/gobject-2.0': 2.86.0-4.0.0-beta.38
+      '@girs/harfbuzz-0.0': 11.5.0-4.0.0-beta.38
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.38
+
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.40':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.40
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/harfbuzz-0.0': 11.5.1-4.0.0-beta.40
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.40
+
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+
+  '@girs/polkit-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/polkitagent-1.0@1.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/polkit-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/shell-17@17.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/atk-1.0': 2.60.0-4.0.0-beta.44
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/clutter-17': 17.0.0-4.0.0-beta.44
+      '@girs/cogl-17': 17.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gck-2': 4.4.0-4.0.0-beta.44
+      '@girs/gcr-4': 4.4.0-4.0.0-beta.44
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/giounix-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/gvc-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/meta-17': 17.0.0-4.0.0-beta.44
+      '@girs/mtk-17': 17.0.0-4.0.0-beta.44
+      '@girs/nm-1.0': 1.56.0-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/polkit-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/polkitagent-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/st-17': 17.0.0-4.0.0-beta.44
+      '@girs/xfixes-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.44
+
+  '@girs/shew-0@0.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/gtk-4.0': 4.22.1-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.44
+
+  '@girs/st-17@17.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/atk-1.0': 2.60.0-4.0.0-beta.44
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/clutter-17': 17.0.0-4.0.0-beta.44
+      '@girs/cogl-17': 17.0.0-4.0.0-beta.44
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.44
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gio-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/glib-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.44
+      '@girs/harfbuzz-0.0': 12.3.2-4.0.0-beta.44
+      '@girs/meta-17': 17.0.0-4.0.0-beta.44
+      '@girs/mtk-17': 17.0.0-4.0.0-beta.44
+      '@girs/pango-1.0': 1.57.0-4.0.0-beta.44
+      '@girs/xfixes-4.0': 4.0.0-4.0.0-beta.44
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.44
+
+  '@girs/upowerglib-1.0@0.99.1-4.0.0-beta.40':
+    dependencies:
+      '@girs/gio-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gjs': 4.0.0-beta.40
+      '@girs/glib-2.0': 2.86.4-4.0.0-beta.40
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.40
+      '@girs/gobject-2.0': 2.86.4-4.0.0-beta.40
+
+  '@girs/xfixes-4.0@4.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@girs/xlib-2.0@2.0.0-4.0.0-beta.44':
+    dependencies:
+      '@girs/gjs': 4.0.0-beta.44
+      '@girs/gobject-2.0': 2.88.0-4.0.0-beta.44
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@pkgr/core@0.1.2': {}
+
+  '@stylistic/eslint-plugin@5.10.0(eslint@9.39.4)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/types': 8.58.0
+      eslint: 9.39.4
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.4
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@typescript-eslint/types@8.58.0': {}
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  are-docs-informative@0.0.2: {}
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.13:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  comment-parser@1.4.1: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  es-module-lexer@1.7.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-gnome@git+https://gitlab.gnome.org/World/javascript/eslint-config-gnome.git#c479d059e8d9ea99c3b53c2ea43abf7fdb05eb51(eslint@9.39.4):
+    dependencies:
+      '@eslint/config-helpers': 0.2.3
+      '@eslint/js': 9.39.4
+      eslint-plugin-jsdoc: 48.11.0(eslint@9.39.4)
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
+
+  eslint-formatter-junit@9.0.1: {}
+
+  eslint-plugin-jsdoc@48.11.0(eslint@9.39.4):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.46.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.4
+      espree: 10.4.0
+      esquery: 1.7.0
+      parse-imports: 2.2.1
+      semver: 7.7.4
+      spdx-expression-parse: 4.0.0
+      synckit: 0.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@4.0.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.13
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-imports@2.2.1:
+    dependencies:
+      es-module-lexer: 1.7.0
+      slashes: 3.0.12
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  resolve-from@4.0.0: {}
+
+  semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  slashes@3.0.12: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  synckit@0.9.3:
+    dependencies:
+      '@pkgr/core': 0.1.2
+      tslib: 2.8.1
+
+  tslib@2.8.1: {}
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/tailscale-gnome-qs@tailscale-qs.github.io/extension.js
+++ b/tailscale-gnome-qs@tailscale-qs.github.io/extension.js
@@ -17,414 +17,441 @@
  */
 
 /* exported init */
-import Clutter from "gi://Clutter";
-import GObject from "gi://GObject";
-import Gio from "gi://Gio";
-import St from "gi://St";
-import GLib from "gi://GLib";
-import * as Config from "resource:///org/gnome/shell/misc/config.js";
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import St from 'gi://St';
+import GLib from 'gi://GLib';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 
-import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-import * as Main from "resource:///org/gnome/shell/ui/main.js";
-import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
-import * as QuickSettings from "resource:///org/gnome/shell/ui/quickSettings.js";
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
 
 // This is the live instance of the Quick Settings menu
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
 
-import { Tailscale } from "./tailscale.js";
-import { filterMullvadNodes, createMullvadExitNodeButton } from "./mullvad.js";
+import {Tailscale} from './tailscale.js';
+import {filterMullvadNodes, createMullvadExitNodeButton} from './mullvad.js';
 
 export const DisableExitNodeButton = GObject.registerClass(
-    class DisableExitNodeButton extends St.Button {
-        _init(tailscale) {
-            const isExitNodeActive = tailscale.exit_node !== "";
+  class DisableExitNodeButton extends St.Button {
+      _init(tailscale) {
+          const isExitNodeActive = tailscale.exit_node !== '';
 
-            super._init({
-                style_class: "icon-button",
-                can_focus: true,
-                icon_name: "network-vpn-symbolic",
-                accessible_name: _("disable exit node"),
-                reactive: isExitNodeActive,
-            });
+          super._init({
+              style_class: 'icon-button',
+              can_focus: true,
+              icon_name: 'network-vpn-symbolic',
+              accessible_name: _('disable exit node'),
+              reactive: isExitNodeActive,
+          });
 
-            this.connect("clicked", () => {
-                tailscale.exit_node = "";
-                this.reactive = false;
-            });
-        }
-    }
+          this.connect('clicked', () => {
+              tailscale.exit_node = '';
+              this.reactive = false;
+          });
+      }
+  }
 );
 
 const TailscaleIndicator = GObject.registerClass(
   class TailscaleIndicator extends QuickSettings.SystemIndicator {
-    _init(icon, tailscale) {
-      super._init();
+      _init(icon, tailscale) {
+          super._init();
 
-      // Create the icon for the indicator
-      const up = this._addIndicator();
-      up.gicon = icon;
-      tailscale.bind_property("running", up, "visible", GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.DEFAULT);
+          // Create the icon for the indicator
+          const up = this._addIndicator();
+          up.gicon = icon;
+          tailscale.bind_property('running', up, 'visible', GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.DEFAULT);
 
-      // Create the icon for the indicator
-      const exit = this._addIndicator();
-      exit.icon_name = "network-vpn-symbolic";
-      const setVisible = () => { exit.visible = tailscale.running && tailscale.exit_node != ""; }
-      tailscale.connect("notify::exit-node", () => setVisible());
-      tailscale.connect("notify::running", () => setVisible());
-      setVisible();
-    }
+          // Create the icon for the indicator
+          const exit = this._addIndicator();
+          exit.icon_name = 'network-vpn-symbolic';
+          const setVisible = () => {
+              exit.visible = tailscale.running && tailscale.exit_node !== '';
+          };
+          tailscale.connect('notify::exit-node', () => setVisible());
+          tailscale.connect('notify::running', () => setVisible());
+          setVisible();
+      }
   }
 );
 
 const TailscaleDeviceItem = GObject.registerClass(
   class TailscaleDeviceItem extends PopupMenu.PopupBaseMenuItem {
-    _init(icon_name, text, subtitle, onClick, onLongClick) {
-      super._init({
-        activate: onClick,
-      });
-
-      const icon = new St.Icon({
-        style_class: 'popup-menu-icon',
-      });
-      this.add_child(icon);
-      icon.icon_name = icon_name;
-
-      const label = new St.Label({
-        x_expand: true,
-      });
-      this.add_child(label);
-      label.text = text;
-
-      const sub = new St.Label({
-        style_class: 'device-subtitle',
-      });
-      this.add_child(sub);
-      sub.text = subtitle;
-
-      this.connect('activate', () => onClick?.());
-      
-      const shellVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
-
-      if (shellVersion >= 47) {
-        const clickGesture = this._clickGesture ?? (() => {
-          const action = new Clutter.ClickGesture();
-          this.add_action(action);
-          action.connect('notify::pressed', () => {
-            if (action.pressed)
-              this.add_style_pseudo_class('active');
-            else
-              this.remove_style_pseudo_class('active');
+      _init(iconName, text, subtitle, onClick, onLongClick) {
+          super._init({
+              activate: onClick,
           });
-          action.connect('recognize', () => this.activate(Clutter.get_current_event()));
-          return action;
-        })();
-        clickGesture.enabled = true;
 
-        const longPressGesture = this._longPressGesture ?? (() => {
-          const action = new Clutter.LongPressGesture();
-          this.add_action(action);
-          action.connect('notify::pressed', () => {
-            if (action.pressed)
-              this.add_style_pseudo_class('active');
-            else
-              this.remove_style_pseudo_class('active');
+          const icon = new St.Icon({
+              style_class: 'popup-menu-icon',
           });
-          action.connect('recognize', () => onLongClick());
-          return action;
-        })();
-        longPressGesture.enabled = true;
-} else {
-        // GNOME 46 fallback - use traditional click handling
-        let pressTimeout = null;
+          this.add_child(icon);
+          icon.icon_name = iconName;
 
-        this.connect('button-press-event', (actor, event) => {
-          if (event.get_button() === 1) {
-            pressTimeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 600, () => {
-              pressTimeout = null;
-              onLongClick?.();
-              return GLib.SOURCE_REMOVE;
-            });
-          }
-          return Clutter.EVENT_PROPAGATE;
-        });
+          const label = new St.Label({
+              x_expand: true,
+          });
+          this.add_child(label);
+          label.text = text;
 
-        this.connect('button-release-event', (actor, event) => {
-          if (event.get_button() === 1) {
-            if (pressTimeout) {
-              // Released before long press fired - treat as normal click
-              GLib.Source.remove(pressTimeout);
-              pressTimeout = null;
-              onClick?.();
-            }
-            return Clutter.EVENT_STOP;
+          const sub = new St.Label({
+              style_class: 'device-subtitle',
+          });
+          this.add_child(sub);
+          sub.text = subtitle;
+
+          this.connect('activate', () => onClick?.());
+
+          const shellVersion = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
+
+          if (shellVersion >= 47) {
+              const clickGesture = this._clickGesture ?? (() => {
+                  const action = new Clutter.ClickGesture();
+                  this.add_action(action);
+                  action.connect('notify::pressed', () => {
+                      if (action.pressed)
+                          this.add_style_pseudo_class('active');
+                      else
+                          this.remove_style_pseudo_class('active');
+                  });
+                  action.connect('recognize', () => this.activate(Clutter.get_current_event()));
+                  return action;
+              })();
+              clickGesture.enabled = true;
+
+              const longPressGesture = this._longPressGesture ?? (() => {
+                  const action = new Clutter.LongPressGesture();
+                  this.add_action(action);
+                  action.connect('notify::pressed', () => {
+                      if (action.pressed)
+                          this.add_style_pseudo_class('active');
+                      else
+                          this.remove_style_pseudo_class('active');
+                  });
+                  action.connect('recognize', () => onLongClick());
+                  return action;
+              })();
+              longPressGesture.enabled = true;
+          } else {
+              // GNOME 46 fallback - use traditional click handling
+              let pressTimeout = null;
+
+              this.connect('button-press-event', (_actor, event) => {
+                  if (event.get_button() === 1) {
+                      pressTimeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 600, () => {
+                          pressTimeout = null;
+                          onLongClick?.();
+                          return GLib.SOURCE_REMOVE;
+                      });
+                  }
+                  return Clutter.EVENT_PROPAGATE;
+              });
+
+              this.connect('button-release-event', (_actor, event) => {
+                  if (event.get_button() === 1) {
+                      if (pressTimeout) {
+                          // Released before long press fired - treat as normal click
+                          GLib.Source.remove(pressTimeout);
+                          pressTimeout = null;
+                          onClick?.();
+                      }
+                      return Clutter.EVENT_STOP;
+                  }
+                  return Clutter.EVENT_PROPAGATE;
+              });
           }
-          return Clutter.EVENT_PROPAGATE;
-        });
       }
-    }
 
-    activate(event) {
-      if (this._activatable)
-        this.emit('activate', event);
-    }
+      activate(event) {
+          if (this._activatable)
+              this.emit('activate', event);
+      }
 
-    vfunc_button_press_event() {
-      if (parseInt(Config.PACKAGE_VERSION.split('.')[0]) >= 47)
-        return;
-    }
+      vfunc_button_press_event() { }
 
-    vfunc_button_release_event() {
-      if (parseInt(Config.PACKAGE_VERSION.split('.')[0]) >= 47)
-        return;
-    }
+      vfunc_button_release_event() { }
 
-    vfunc_touch_event(touchEvent) { }
+      vfunc_touch_event(_touchEvent) { }
   }
 );
 
 const TailscaleProfileItem = GObject.registerClass(
   class TailscaleProfileItem extends PopupMenu.PopupBaseMenuItem {
-    _init(title, subtitle, enabled, onClick) {
-      super._init({
-        activate: onClick,
-      });
+      _init(title, subtitle, enabled, onClick) {
+          super._init({
+              activate: onClick,
+          });
 
-      const label = new St.Label({
-        x_expand: true,
-      });
-      this.add_child(label);
-      label.text = title;
+          const label = new St.Label({
+              x_expand: true,
+          });
+          this.add_child(label);
+          label.text = title;
 
-      const sub = new St.Label({
-        style_class: 'device-subtitle',
-      });
-      this.add_child(sub);
-      sub.text = subtitle;
+          const sub = new St.Label({
+              style_class: 'device-subtitle',
+          });
+          this.add_child(sub);
+          sub.text = subtitle;
 
-      if (enabled) {
-        const icon = new St.Icon({ style_class: 'system-status-icon' });
-        this.add_child(icon);
-        icon.icon_name = 'object-select-symbolic'
+          if (enabled) {
+              const icon = new St.Icon({style_class: 'system-status-icon'});
+              this.add_child(icon);
+              icon.icon_name = 'object-select-symbolic';
+          }
+
+          this.connect('activate', () => onClick());
       }
 
-      this.connect('activate', () => onClick());
-    }
-
-    activate(event) {
-      if (this._activatable)
-        this.emit('activate', event);
-    }
+      activate(event) {
+          if (this._activatable)
+              this.emit('activate', event);
+      }
   }
 );
 
 const PopupScrollableSubMenuMenuItem = GObject.registerClass(
   class PopupScrollableSubMenuMenuItem extends PopupMenu.PopupSubMenuMenuItem {
-    _init(props) {
-      super._init(props);
+      _init(props) {
+          super._init(props);
 
-      this.menu._needsScrollbar = () => true;
-      this.menu.box.height = 200;
-    }
+          this.menu._needsScrollbar = () => true;
+          this.menu.box.height = 200;
+      }
   }
 );
 
 const TailscaleMenuToggle = GObject.registerClass(
   class TailscaleMenuToggle extends QuickSettings.QuickMenuToggle {
-    _init(icon, tailscale) {
-      super._init({
-        label: "Tailscale",
-        gicon: icon,
-        toggleMode: true,
-        menuEnabled: true,
-      });
+      _getIconName(node) {
+          if (!node.online)
+              return 'network-offline-symbolic';
 
-      this.title = "Tailscale";
-      tailscale.bind_property("running", this, "checked", GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.BIDIRECTIONAL);
+          if (node.os === 'android' || node.os === 'iOS')
+              return 'phone-symbolic';
 
-      // Header action bar section
-      const actionLayout = new Clutter.GridLayout();
-      const actionBar = new St.Widget({
-          layout_manager: actionLayout,
-      });
+          if (node.mullvad)
+              return 'network-vpn-symbolic';
 
-      this.menu._headerSpacer.x_align = Clutter.ActorAlign.END;
-      this.menu._headerSpacer.add_child(actionBar);
+          return 'computer-symbolic';
+      }
 
-      const disableExitNodeButton = new DisableExitNodeButton(tailscale);
-      actionLayout.attach(disableExitNodeButton, 0, 0, 1, 1);
+      _getNodeSubtitle(node) {
+          if (node.exit_node)
+              return _('disable exit node');
+          if (node.exit_node_option)
+              return _('use as exit node');
 
-      // This function is unique to this class. It adds a nice header with an
-      // icon, title and optional subtitle. It's recommended you do so for
-      // consistency with other menus.
-      tailscale.connect("notify::exit-node-name", () => {
-        this.subtitle = tailscale.exit_node_name;
-        this.menu.setHeader(icon, this.title, this.subtitle);
-        disableExitNodeButton.reactive = tailscale.exit_node !== "";
-      });
-      this.menu.setHeader(icon, this.title, tailscale.exit_node_name);
+          return '';
+      }
 
-      // NODES
-      const mnodes = new PopupScrollableSubMenuMenuItem(_("Nodes"), false, {});
-      const nodes = new PopupMenu.PopupMenuSection();
+      _init(icon, tailscale) {
+          super._init({
+              label: 'Tailscale',
+              gicon: icon,
+              toggleMode: true,
+              menuEnabled: true,
+          });
 
-      // Keep track of available Mullvad nodes
-      let availableMullvadNodes = [];
-      let mullvadButtonItem = null;
+          this.title = 'Tailscale';
+          tailscale.bind_property('running', this, 'checked', GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.BIDIRECTIONAL);
 
-      const update_nodes = (obj) => {
-        nodes.removeAll();
+          // Header action bar section
+          const actionLayout = new Clutter.GridLayout();
+          const actionBar = new St.Widget({
+              layout_manager: actionLayout,
+          });
 
-        // Separate Mullvad nodes from regular nodes and filter only online Mullvad nodes
-        availableMullvadNodes = filterMullvadNodes(obj.nodes);
-        const regularNodes = obj.nodes.filter(node => !node.mullvad || node.exit_node);
+          this.menu._headerSpacer.x_align = Clutter.ActorAlign.END;
+          this.menu._headerSpacer.add_child(actionBar);
 
-        // Add regular nodes to main menu
-        for (const node of regularNodes) {
-          const device_icon = !node.online
-            ? "network-offline-symbolic"
-            : ((node.os == "android" || node.os == "iOS")
-              ? "phone-symbolic"
-              : (node.mullvad
-                ? "network-vpn-symbolic"
-                : "computer-symbolic"));
-          const subtitle = node.exit_node ? _("disable exit node") : (node.exit_node_option ? _("use as exit node") : "");
-          const onClick = node.exit_node_option ? () => { tailscale.exit_node = node.exit_node ? "" : node.id; } : null;
-          const onLongClick = () => {
-            if (!node.ips)
-              return false;
+          const disableExitNodeButton = new DisableExitNodeButton(tailscale);
+          actionLayout.attach(disableExitNodeButton, 0, 0, 1, 1);
 
-            St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, node.ips[0]);
-            St.Clipboard.get_default().set_text(St.ClipboardType.PRIMARY, node.ips[0]);
-            Main.osdWindowManager.showAll(icon, _("IP address has been copied to the clipboard"));
-            return true;
+          // This function is unique to this class. It adds a nice header with an
+          // icon, title and optional subtitle. It's recommended you do so for
+          // consistency with other menus.
+          tailscale.connect('notify::exit-node-name', () => {
+              this.subtitle = tailscale.exit_node_name;
+              this.menu.setHeader(icon, this.title, this.subtitle);
+              disableExitNodeButton.reactive = tailscale.exit_node !== '';
+          });
+          this.menu.setHeader(icon, this.title, tailscale.exit_node_name);
+
+          // NODES
+          const mnodes = new PopupScrollableSubMenuMenuItem(_('Nodes'), false, {});
+          const nodes = new PopupMenu.PopupMenuSection();
+
+          // Keep track of available Mullvad nodes
+          let availableMullvadNodes = [];
+          let mullvadButtonItem = null;
+
+          const updateNodes = obj => {
+              nodes.removeAll();
+
+              // Separate Mullvad nodes from regular nodes and filter only online Mullvad nodes
+              availableMullvadNodes = filterMullvadNodes(obj.nodes);
+              const regularNodes = obj.nodes.filter(node => !node.mullvad || node.exit_node);
+
+              // Add regular nodes to main menu
+              for (const node of regularNodes) {
+                  const deviceIcon = this._getIconName(node);
+                  const subtitle = this._getNodeSubtitle(node);
+                  const onClick = node.exit_node_option ? () => {
+                      tailscale.exit_node = node.exit_node ? '' : node.id;
+                  } : null;
+                  const onLongClick = () => {
+                      if (!node.ips)
+                          return false;
+
+                      St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, node.ips[0]);
+                      St.Clipboard.get_default().set_text(St.ClipboardType.PRIMARY, node.ips[0]);
+                      Main.osdWindowManager.showAll(icon, _('IP address has been copied to the clipboard'));
+                      return true;
+                  };
+
+                  nodes.addMenuItem(new TailscaleDeviceItem(deviceIcon, node.name, subtitle, onClick, onLongClick));
+              }
+
+              // Update Mullvad button visibility
+              this._updateMullvadButton();
           };
 
-          nodes.addMenuItem(new TailscaleDeviceItem(device_icon, node.name, subtitle, onClick, onLongClick));
-        }
+          // Method to create or remove Mullvad button based on available nodes
+          this._updateMullvadButton = () => {
+              // Remove existing button if it exists
+              if (mullvadButtonItem) {
+                  mullvadButtonItem.destroy();
+                  mullvadButtonItem = null;
+              }
 
-        // Update Mullvad button visibility
-        this._updateMullvadButton();
-      };
+              // Create new button using the helper function
+              mullvadButtonItem = createMullvadExitNodeButton(availableMullvadNodes, tailscale);
 
-      // Method to create or remove Mullvad button based on available nodes
-      this._updateMullvadButton = () => {
-        // Remove existing button if it exists
-        if (mullvadButtonItem) {
-          mullvadButtonItem.destroy();
-          mullvadButtonItem = null;
-        }
+              // Add it to the main menu if it was created
+              if (mullvadButtonItem)
+                  this.menu.addMenuItem(mullvadButtonItem);
+          };
 
-        // Create new button using the helper function
-        mullvadButtonItem = createMullvadExitNodeButton(availableMullvadNodes, tailscale);
+          tailscale.connect('notify::nodes', obj => updateNodes(obj));
+          updateNodes(tailscale);
+          mnodes.menu.addMenuItem(nodes);
+          this.menu.addMenuItem(mnodes);
 
-        // Add it to the main menu if it was created
-        if (mullvadButtonItem) {
-          this.menu.addMenuItem(mullvadButtonItem);
-        }
-      };
+          // SEPARATOR
+          this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-      tailscale.connect("notify::nodes", (obj) => update_nodes(obj));
-      update_nodes(tailscale);
-      mnodes.menu.addMenuItem(nodes);
-      this.menu.addMenuItem(mnodes);
+          // PREFS
+          const prefs = new PopupMenu.PopupSubMenuMenuItem(_('Settings'), false, {});
 
-      // SEPARATOR
-      this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+          const routes = new PopupMenu.PopupSwitchMenuItem(_('Accept routes'), tailscale.accept_routes, {});
+          tailscale.connect('notify::accept-routes', obj => routes.setToggleState(obj.accept_routes));
+          routes.connect('toggled', item => {
+              tailscale.accept_routes = item.state;
+          });
+          prefs.menu.addMenuItem(routes);
 
-      // PREFS
-      const prefs = new PopupMenu.PopupSubMenuMenuItem(_("Settings"), false, {});
+          const dns = new PopupMenu.PopupSwitchMenuItem(_('Accept DNS'), tailscale.accept_dns, {});
+          tailscale.connect('notify::accept-dns', obj => dns.setToggleState(obj.accept_dns));
+          dns.connect('toggled', item => {
+              tailscale.accept_dns = item.state;
+          });
+          prefs.menu.addMenuItem(dns);
 
-      const routes = new PopupMenu.PopupSwitchMenuItem(_("Accept routes"), tailscale.accept_routes, {});
-      tailscale.connect("notify::accept-routes", (obj) => routes.setToggleState(obj.accept_routes));
-      routes.connect("toggled", (item) => tailscale.accept_routes = item.state);
-      prefs.menu.addMenuItem(routes);
+          const lan = new PopupMenu.PopupSwitchMenuItem(_('Allow LAN access'), tailscale.allow_lan_access, {});
+          tailscale.connect('notify::allow-lan-access', obj => lan.setToggleState(obj.allow_lan_access));
+          lan.connect('toggled', item => {
+              tailscale.allow_lan_access = item.state;
+          });
+          prefs.menu.addMenuItem(lan);
 
-      const dns = new PopupMenu.PopupSwitchMenuItem(_("Accept DNS"), tailscale.accept_dns, {});
-      tailscale.connect("notify::accept-dns", (obj) => dns.setToggleState(obj.accept_dns));
-      dns.connect("toggled", (item) => tailscale.accept_dns = item.state);
-      prefs.menu.addMenuItem(dns);
+          const shields = new PopupMenu.PopupSwitchMenuItem(_('Shields up'), tailscale.shields_up, {});
+          tailscale.connect('notify::shields-up', obj => shields.setToggleState(obj.shields_up));
+          shields.connect('toggled', item => {
+              tailscale.shields_up = item.state;
+          });
+          prefs.menu.addMenuItem(shields);
 
-      const lan = new PopupMenu.PopupSwitchMenuItem(_("Allow LAN access"), tailscale.allow_lan_access, {});
-      tailscale.connect("notify::allow-lan-access", (obj) => lan.setToggleState(obj.allow_lan_access));
-      lan.connect("toggled", (item) => tailscale.allow_lan_access = item.state);
-      prefs.menu.addMenuItem(lan);
+          const ssh = new PopupMenu.PopupSwitchMenuItem(_('SSH'), tailscale.ssh, {});
+          tailscale.connect('notify::ssh', obj => ssh.setToggleState(obj.ssh));
+          ssh.connect('toggled', item => {
+              tailscale.ssh = item.state;
+          });
+          prefs.menu.addMenuItem(ssh);
 
-      const shields = new PopupMenu.PopupSwitchMenuItem(_("Shields up"), tailscale.shields_up, {});
-      tailscale.connect("notify::shields-up", (obj) => shields.setToggleState(obj.shields_up));
-      shields.connect("toggled", (item) => tailscale.shields_up = item.state);
-      prefs.menu.addMenuItem(shields);
+          this.menu.addMenuItem(prefs);
 
-      const ssh = new PopupMenu.PopupSwitchMenuItem(_("SSH"), tailscale.ssh, {});
-      tailscale.connect("notify::ssh", (obj) => ssh.setToggleState(obj.ssh));
-      ssh.connect("toggled", (item) => tailscale.ssh = item.state);
-      prefs.menu.addMenuItem(ssh);
-
-      this.menu.addMenuItem(prefs);
-      
-      // PROFILES
-      const profiles = new PopupMenu.PopupSubMenuMenuItem(_("Profiles"), false, {});
-      const update_profiles = (obj) => {
-        profiles.menu.removeAll();
-        for (const p of obj.profiles) {
-          if (!p.NetworkProfile || !p.NetworkProfile.DomainName) continue; // Skip invalid profiles
-          let enabled = obj._prefs.ControlURL === p.ControlURL && obj._prefs.Config.UserProfile.ID === p.UserProfile.ID;
-          const onClick = () => { tailscale.profiles = p.ID; }
-          profiles.menu.addMenuItem(new TailscaleProfileItem(p.NetworkProfile.DisplayName? p.NetworkProfile.DisplayName : p.Name, p.NetworkProfile.DomainName, enabled, onClick));
-        }
+          // PROFILES
+          const profiles = new PopupMenu.PopupSubMenuMenuItem(_('Profiles'), false, {});
+          const updateProfiles = obj => {
+              profiles.menu.removeAll();
+              for (const p of obj.profiles) {
+                  if (!p.NetworkProfile || !p.NetworkProfile.DomainName)
+                      continue; // Skip invalid profiles
+                  const enabled = obj._prefs.ControlURL === p.ControlURL && obj._prefs.Config.UserProfile.ID === p.UserProfile.ID;
+                  const onClick = () => {
+                      tailscale.profiles = p.ID;
+                  };
+                  profiles.menu.addMenuItem(new TailscaleProfileItem(p.NetworkProfile.DisplayName ? p.NetworkProfile.DisplayName : p.Name, p.NetworkProfile.DomainName, enabled, onClick));
+              }
+          };
+          tailscale.connect('notify::profiles', obj => updateProfiles(obj));
+          updateProfiles(tailscale);
+          this.menu.addMenuItem(profiles);
       }
-      tailscale.connect("notify::profiles", (obj) => update_profiles(obj));
-      update_profiles(tailscale);
-      this.menu.addMenuItem(profiles);
-    }
   }
 );
 
 export default class TailscaleExtension extends Extension {
-  _timeouts = [];
+    _timeouts = [];
 
-  enable() {
-    const icon = Gio.icon_new_for_string(`${this.path}/icons/tailscale-symbolic.svg`);
+    enable() {
+        const icon = Gio.icon_new_for_string(`${this.path}/icons/tailscale-symbolic.svg`);
 
-    this._tailscale = new Tailscale();
-    this._indicator = new TailscaleIndicator(icon, this._tailscale);
-    this._menu = new TailscaleMenuToggle(icon, this._tailscale);
-    if (QuickSettingsMenu.addExternalIndicator) {
-      this._indicator.quickSettingsItems.push(this._menu);
-      QuickSettingsMenu.addExternalIndicator(this._indicator);
-    } else {
-      const timerHandle = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
-        if (!QuickSettingsMenu._indicators.get_first_child())
-          return GLib.SOURCE_CONTINUE;
+        this._tailscale = new Tailscale();
+        this._indicator = new TailscaleIndicator(icon, this._tailscale);
+        this._menu = new TailscaleMenuToggle(icon, this._tailscale);
+        if (QuickSettingsMenu.addExternalIndicator) {
+            this._indicator.quickSettingsItems.push(this._menu);
+            QuickSettingsMenu.addExternalIndicator(this._indicator);
+        } else {
+            const timerHandle = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, () => {
+                if (!QuickSettingsMenu._indicators.get_first_child())
+                    return GLib.SOURCE_CONTINUE;
 
-        QuickSettingsMenu._indicators.insert_child_at_index(this._indicator, 0);
-        QuickSettingsMenu._addItems([this._menu]);
-        QuickSettingsMenu.menu._grid.set_child_below_sibling(
-          this._menu,
-          QuickSettingsMenu._backgroundApps.quickSettingsItems[0]
-        );
+                QuickSettingsMenu._indicators.insert_child_at_index(this._indicator, 0);
+                QuickSettingsMenu._addItems([this._menu]);
+                QuickSettingsMenu.menu._grid.set_child_below_sibling(
+                    this._menu,
+                    QuickSettingsMenu._backgroundApps.quickSettingsItems[0]
+                );
 
-        // Remove from tracking and stop
-        const index = this._timeouts.indexOf(timerHandle);
-        if (index > -1) this._timeouts.splice(index, 1);
-        return GLib.SOURCE_REMOVE;
-      });
-      this._timeouts.push(timerHandle);
+                // Remove from tracking and stop
+                const index = this._timeouts.indexOf(timerHandle);
+                if (index > -1)
+                    this._timeouts.splice(index, 1);
+                return GLib.SOURCE_REMOVE;
+            });
+            this._timeouts.push(timerHandle);
+        }
     }
-  }
 
-  disable() {
-    this._timeouts.forEach(id => GLib.Source.remove(id));
-    this._timeouts = [];
+    disable() {
+        this._timeouts.forEach(id => GLib.Source.remove(id));
+        this._timeouts = [];
 
-    this._menu.destroy();
-    this._menu = null;
+        this._menu.destroy();
+        this._menu = null;
 
-    this._indicator.destroy();
-    this._indicator = null;
+        this._indicator.destroy();
+        this._indicator = null;
 
-    this._tailscale.destroy();
-    this._tailscale = null;
-  }
+        this._tailscale.destroy();
+        this._tailscale = null;
+    }
 }

--- a/tailscale-gnome-qs@tailscale-qs.github.io/mullvad.js
+++ b/tailscale-gnome-qs@tailscale-qs.github.io/mullvad.js
@@ -10,16 +10,18 @@ import {gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js'
 
 /**
  * Convert a country code to a flag emoji
+ *
  * @param {string} countryCode - The ISO 3166-1 alpha-2 country code
  * @returns {string} The flag emoji for the country
  */
 function getCountryFlag(countryCode) {
-  if (!countryCode) return '';
+    if (!countryCode)
+        return '';
 
-  // Convert country code to flag emoji
-  // Each letter in the country code is converted to a regional indicator symbol
-  // by adding 127397 to its Unicode code point
-  return countryCode
+    // Convert country code to flag emoji
+    // Each letter in the country code is converted to a regional indicator symbol
+    // by adding 127397 to its Unicode code point
+    return countryCode
     .split('')
     .map(char => String.fromCodePoint(char.charCodeAt(0) + 127397))
     .join('');
@@ -34,931 +36,955 @@ function getCountryFlag(countryCode) {
  * A menu item representing a Mullvad exit node
  *
  * @class MullvadNodeItem
- * @extends PopupMenu.PopupBaseMenuItem
+ * @augments PopupMenu.PopupBaseMenuItem
  */
 export const MullvadNodeItem = GObject.registerClass({
-  Properties: {
+    Properties: {
     /**
      * Whether this node is currently selected
      */
-    'selected': GObject.ParamSpec.boolean(
-      'selected', 'Selected', 'Whether this node is selected',
-      GObject.ParamFlags.READWRITE,
-      false)
-  }
+        'selected': GObject.ParamSpec.boolean(
+            'selected', 'Selected', 'Whether this node is selected',
+            GObject.ParamFlags.READWRITE,
+            false),
+    },
 }, class MullvadNodeItem extends PopupMenu.PopupBaseMenuItem {
-  /**
-   * Create a new MullvadNodeItem
-   *
-   * @param {string} name - The node name
-   * @param {string} nodeId - The node ID
-   * @param {number} priority - The node priority (lower is better)
-   * @param {boolean} isSelected - Whether this node is currently selected
-   */
-  _init(name, nodeId, priority, isSelected) {
-    super._init({
-      style_class: 'mullvad-node-item popup-menu-item',
-      activate: true,
-    });
+    /**
+     * Create a new MullvadNodeItem
+     *
+     * @param {string} name - The node name
+     * @param {string} nodeId - The node ID
+     * @param {number} priority - The node priority (lower is better)
+     * @param {boolean} isSelected - Whether this node is currently selected
+     */
+    _init(name, nodeId, priority, isSelected) {
+        super._init({
+            style_class: 'mullvad-node-item popup-menu-item',
+            activate: true,
+        });
 
-    this.name = name;
-    this.nodeId = nodeId;
-    this.priority = priority;
-    this._selected = isSelected || false;
+        this.name = name;
+        this.nodeId = nodeId;
+        this.priority = priority;
+        this._selected = isSelected || false;
 
-    // Add indentation to visually distinguish from location items
-    this.style = 'padding-left: 24px; margin-top: 2px; margin-bottom: 2px;';
+        // Add indentation to visually distinguish from location items
+        this.style = 'padding-left: 24px; margin-top: 2px; margin-bottom: 2px;';
 
-    this._createUI();
-    this.connect('notify::selected', () => this._updateSelection());
-  }
+        this._createUI();
+        this.connect('notify::selected', () => this._updateSelection());
+    }
 
-  /**
-   * Create and set up the UI elements
-   * @private
-   */
-  _createUI() {
+    /**
+     * Create and set up the UI elements
+     *
+     * @private
+     */
+    _createUI() {
     // Main content container
-    const contentBox = new St.BoxLayout({
-      style_class: 'mullvad-node-content',
-      vertical: true,
-      x_expand: true,
-      x_align: Clutter.ActorAlign.START,
-      y_align: Clutter.ActorAlign.CENTER
-    });
-    this.add_child(contentBox);
+        const contentBox = new St.BoxLayout({
+            style_class: 'mullvad-node-content',
+            vertical: true,
+            x_expand: true,
+            x_align: Clutter.ActorAlign.START,
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this.add_child(contentBox);
 
-    // Node name
-    this.nameLabel = new St.Label({
-      style_class: 'mullvad-node-name',
-      text: this.name,
-      x_align: Clutter.ActorAlign.START
-    });
-    contentBox.add_child(this.nameLabel);
+        // Node name
+        this.nameLabel = new St.Label({
+            style_class: 'mullvad-node-name',
+            text: this.name,
+            x_align: Clutter.ActorAlign.START,
+        });
+        contentBox.add_child(this.nameLabel);
 
-    // Selection indicator
-    this.checkIcon = new St.Icon({
-      style_class: 'mullvad-selection-icon',
-      icon_name: 'object-select-symbolic',
-      icon_size: 16,
-      visible: this._selected,
-      x_align: Clutter.ActorAlign.END,
-      y_align: Clutter.ActorAlign.CENTER
-    });
-    this.add_child(this.checkIcon);
+        // Selection indicator
+        this.checkIcon = new St.Icon({
+            style_class: 'mullvad-selection-icon',
+            icon_name: 'object-select-symbolic',
+            icon_size: 16,
+            visible: this._selected,
+            x_align: Clutter.ActorAlign.END,
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this.add_child(this.checkIcon);
 
-    // Apply initial selection state
-    this._updateSelection();
-  }
-
-  /**
-   * Get the selected state
-   * @returns {boolean} Whether this item is selected
-   */
-  get selected() {
-    return this._selected;
-  }
-
-  /**
-   * Set the selected state
-   * @param {boolean} value - The new selected state
-   */
-  set selected(value) {
-    if (this._selected !== value) {
-      this._selected = value;
-      this.notify('selected');
+        // Apply initial selection state
+        this._updateSelection();
     }
-  }
 
-  /**
-   * Update the UI to reflect the current selection state
-   * @private
-   */
-  _updateSelection() {
-    this.checkIcon.visible = this._selected;
-
-    if (this._selected) {
-      this.add_style_pseudo_class('selected');
-    } else {
-      this.remove_style_pseudo_class('selected');
+    /**
+     * Get the selected state
+     *
+     * @returns {boolean} Whether this item is selected
+     */
+    get selected() {
+        return this._selected;
     }
-  }
 
-  /**
-   * Override the activate method to emit the activate signal
-   * This allows the item to be activated by keyboard or mouse
-   *
-   * @param {Clutter.Event} event - The event that triggered the activation
-   */
-  activate(event) {
-    if (this._activatable) {
-      this.emit('activate', event);
+    /**
+     * Set the selected state
+     *
+     * @param {boolean} value - The new selected state
+     */
+    set selected(value) {
+        if (this._selected !== value) {
+            this._selected = value;
+            this.notify('selected');
+        }
     }
-  }
+
+    /**
+     * Update the UI to reflect the current selection state
+     *
+     * @private
+     */
+    _updateSelection() {
+        this.checkIcon.visible = this._selected;
+
+        if (this._selected)
+            this.add_style_pseudo_class('selected');
+        else
+            this.remove_style_pseudo_class('selected');
+    }
+
+    /**
+     * Override the activate method to emit the activate signal
+     * This allows the item to be activated by keyboard or mouse
+     *
+     * @param {Clutter.Event} event - The event that triggered the activation
+     */
+    activate(event) {
+        if (this._activatable)
+            this.emit('activate', event);
+    }
 });
 
 /**
  * A menu item representing a Mullvad exit node location (city/country)
  *
  * @class MullvadLocationItem
- * @extends PopupMenu.PopupBaseMenuItem
+ * @augments PopupMenu.PopupBaseMenuItem
  */
 export const MullvadLocationItem = GObject.registerClass({
-  Properties: {
+    Properties: {
     /**
      * Whether this location is currently selected
      */
-    'selected': GObject.ParamSpec.boolean(
-      'selected', 'Selected', 'Whether this location is selected',
-      GObject.ParamFlags.READWRITE,
-      false),
-    /**
-     * Whether this location is expanded to show nodes
-     */
-    'expanded': GObject.ParamSpec.boolean(
-      'expanded', 'Expanded', 'Whether this location is expanded to show nodes',
-      GObject.ParamFlags.READWRITE,
-      false)
-  },
-  Signals: {
-    'expand-toggled': { param_types: [GObject.TYPE_BOOLEAN] }
-  }
+        'selected': GObject.ParamSpec.boolean(
+            'selected', 'Selected', 'Whether this location is selected',
+            GObject.ParamFlags.READWRITE,
+            false),
+        /**
+         * Whether this location is expanded to show nodes
+         */
+        'expanded': GObject.ParamSpec.boolean(
+            'expanded', 'Expanded', 'Whether this location is expanded to show nodes',
+            GObject.ParamFlags.READWRITE,
+            false),
+    },
+    Signals: {
+        'expand-toggled': {param_types: [GObject.TYPE_BOOLEAN]},
+    },
 }, class MullvadLocationItem extends PopupMenu.PopupBaseMenuItem {
-  /**
-   * Create a new MullvadLocationItem
-   *
-   * @param {string} city - The city name
-   * @param {string} country - The country name
-   * @param {number} nodeCount - Number of available nodes at this location
-   * @param {Object} bestNode - The best node object for this location
-   * @param {Array} nodes - All nodes for this location
-   * @param {string} countryCode - The country code (ISO 3166-1 alpha-2)
-   */
-  _init(city, country, nodeCount, bestNode, nodes, countryCode) {
-    super._init({
-      style_class: 'mullvad-location-item popup-menu-item',
-      activate: true,
-    });
+    /**
+     * Create a new MullvadLocationItem
+     *
+     * @param {string} city - The city name
+     * @param {string} country - The country name
+     * @param {number} nodeCount - Number of available nodes at this location
+     * @param {object} bestNode - The best node object for this location
+     * @param {Array} nodes - All nodes for this location
+     * @param {string} countryCode - The country code (ISO 3166-1 alpha-2)
+     */
+    _init(city, country, nodeCount, bestNode, nodes, countryCode) {
+        super._init({
+            style_class: 'mullvad-location-item popup-menu-item',
+            activate: true,
+        });
 
-    this.city = city;
-    this.country = country;
-    this.nodeCount = nodeCount;
-    this.bestNode = bestNode;
-    this.nodes = nodes;
-    this.countryCode = countryCode;
-    this._selected = false;
-    this._expanded = false;
+        this.city = city;
+        this.country = country;
+        this.nodeCount = nodeCount;
+        this.bestNode = bestNode;
+        this.nodes = nodes;
+        this.countryCode = countryCode;
+        this._selected = false;
+        this._expanded = false;
 
-    this._createUI();
-    this.connect('notify::selected', () => this._updateSelection());
-    this.connect('notify::expanded', () => this._updateExpanded());
-  }
+        this._createUI();
+        this.connect('notify::selected', () => this._updateSelection());
+        this.connect('notify::expanded', () => this._updateExpanded());
+    }
 
-  /**
-   * Create and set up the UI elements
-   * @private
-   */
-  _createUI() {
+    /**
+     * Create and set up the UI elements
+     *
+     * @private
+     */
+    _createUI() {
     // Main content container
-    const contentBox = new St.BoxLayout({
-      style_class: 'mullvad-location-content',
-      vertical: true,
-      x_expand: true
-    });
-    this.add_child(contentBox);
+        const contentBox = new St.BoxLayout({
+            style_class: 'mullvad-location-content',
+            vertical: true,
+            x_expand: true,
+        });
+        this.add_child(contentBox);
 
-    // Title: City, Country (with country in bold)
-    this.titleLabel = new St.Label({
-      style_class: 'mullvad-location-title title',
-    });
-    // Set markup for bold country name
-    this.titleLabel.clutter_text.set_markup(`${this.city} <b>${this.country}</b>`);
-    contentBox.add_child(this.titleLabel);
+        // Title: City, Country (with country in bold)
+        this.titleLabel = new St.Label({
+            style_class: 'mullvad-location-title title',
+        });
+        // Set markup for bold country name
+        this.titleLabel.clutter_text.set_markup(`${this.city} <b>${this.country}</b>`);
+        contentBox.add_child(this.titleLabel);
 
-    // Subtitle: Node count
-    const nodesText = this.nodeCount === 1 ? _('node') : _('nodes');
-    this.subtitleLabel = new St.Label({
-      style_class: 'mullvad-location-subtitle subtitle',
-      text: `${this.nodeCount} ${nodesText} online`,
-    });
-    contentBox.add_child(this.subtitleLabel);
+        // Subtitle: Node count
+        const nodesText = this.nodeCount === 1 ? _('node') : _('nodes');
+        this.subtitleLabel = new St.Label({
+            style_class: 'mullvad-location-subtitle subtitle',
+            text: `${this.nodeCount} ${nodesText} online`,
+        });
+        contentBox.add_child(this.subtitleLabel);
 
-    // Selection indicator
-    this.checkIcon = new St.Icon({
-      style_class: 'mullvad-selection-icon',
-      icon_name: 'object-select-symbolic',
-      icon_size: 16,
-      visible: false,
-      x_align: Clutter.ActorAlign.END,
-      y_align: Clutter.ActorAlign.CENTER
-    });
-    this.add_child(this.checkIcon);
+        // Selection indicator
+        this.checkIcon = new St.Icon({
+            style_class: 'mullvad-selection-icon',
+            icon_name: 'object-select-symbolic',
+            icon_size: 16,
+            visible: false,
+            x_align: Clutter.ActorAlign.END,
+            y_align: Clutter.ActorAlign.CENTER,
+        });
+        this.add_child(this.checkIcon);
 
-    // Country flag
-    const flagEmoji = getCountryFlag(this.countryCode);
-    this.flagLabel = new St.Label({
-      style_class: 'mullvad-country-flag',
-      text: flagEmoji,
-      x_align: Clutter.ActorAlign.END,
-      y_align: Clutter.ActorAlign.CENTER,
-      style: 'font-size: 16px; margin-right: 8px;'
-    });
-    this.add_child(this.flagLabel);
+        // Country flag
+        const flagEmoji = getCountryFlag(this.countryCode);
+        this.flagLabel = new St.Label({
+            style_class: 'mullvad-country-flag',
+            text: flagEmoji,
+            x_align: Clutter.ActorAlign.END,
+            y_align: Clutter.ActorAlign.CENTER,
+            style: 'font-size: 16px; margin-right: 8px;',
+        });
+        this.add_child(this.flagLabel);
 
-    // Expand button
-    this.expandButton = new St.Button({
-      style_class: 'mullvad-expand-button icon-button',
-      x_align: Clutter.ActorAlign.END,
-      y_align: Clutter.ActorAlign.CENTER,
-      can_focus: true
-    });
+        // Expand button
+        this.expandButton = new St.Button({
+            style_class: 'mullvad-expand-button icon-button',
+            x_align: Clutter.ActorAlign.END,
+            y_align: Clutter.ActorAlign.CENTER,
+            can_focus: true,
+        });
 
-    this.expandIcon = new St.Icon({
-      style_class: 'mullvad-expand-icon',
-      icon_name: 'go-down-symbolic',
-      icon_size: 16
-    });
+        this.expandIcon = new St.Icon({
+            style_class: 'mullvad-expand-icon',
+            icon_name: 'go-down-symbolic',
+            icon_size: 16,
+        });
 
-    this.expandButton.set_child(this.expandIcon);
-    this.expandButton.connect('clicked', (actor, event) => {
-      // Stop propagation to prevent the item from being activated
-      this.expanded = !this.expanded;
-      this.emit('expand-toggled', this.expanded);
-      return Clutter.EVENT_STOP;
-    });
+        this.expandButton.set_child(this.expandIcon);
+        this.expandButton.connect('clicked', (_actor, _event) => {
+            // Stop propagation to prevent the item from being activated
+            this.expanded = !this.expanded;
+            this.emit('expand-toggled', this.expanded);
+            return Clutter.EVENT_STOP;
+        });
 
-    this.add_child(this.expandButton);
-  }
-
-  /**
-   * Update the UI to reflect the current expanded state
-   * @private
-   */
-  _updateExpanded() {
-    if (this._expanded) {
-      this.expandIcon.icon_name = 'go-up-symbolic';
-    } else {
-      this.expandIcon.icon_name = 'go-down-symbolic';
+        this.add_child(this.expandButton);
     }
-  }
 
-  /**
-   * Get the selected state
-   * @returns {boolean} Whether this item is selected
-   */
-  get selected() {
-    return this._selected;
-  }
-
-  /**
-   * Set the selected state
-   * @param {boolean} value - The new selected state
-   */
-  set selected(value) {
-    if (this._selected !== value) {
-      this._selected = value;
-      this.notify('selected');
+    /**
+     * Update the UI to reflect the current expanded state
+     *
+     * @private
+     */
+    _updateExpanded() {
+        if (this._expanded)
+            this.expandIcon.icon_name = 'go-up-symbolic';
+        else
+            this.expandIcon.icon_name = 'go-down-symbolic';
     }
-  }
 
-  /**
-   * Get the expanded state
-   * @returns {boolean} Whether this item is expanded
-   */
-  get expanded() {
-    return this._expanded;
-  }
-
-  /**
-   * Set the expanded state
-   * @param {boolean} value - The new expanded state
-   */
-  set expanded(value) {
-    if (this._expanded !== value) {
-      this._expanded = value;
-      this.notify('expanded');
+    /**
+     * Get the selected state
+     *
+     * @returns {boolean} Whether this item is selected
+     */
+    get selected() {
+        return this._selected;
     }
-  }
 
-  /**
-   * Update the UI to reflect the current selection state
-   * @private
-   */
-  _updateSelection() {
-    this.checkIcon.visible = this._selected;
-
-    if (this._selected) {
-      this.add_style_pseudo_class('selected');
-    } else {
-      this.remove_style_pseudo_class('selected');
+    /**
+     * Set the selected state
+     *
+     * @param {boolean} value - The new selected state
+     */
+    set selected(value) {
+        if (this._selected !== value) {
+            this._selected = value;
+            this.notify('selected');
+        }
     }
-  }
 
-  /**
-   * Override the activate method to emit the activate signal
-   * This allows the item to be activated by keyboard or mouse
-   *
-   * @param {Clutter.Event} event - The event that triggered the activation
-   */
-  activate(event) {
-    if (this._activatable) {
-      this.emit('activate', event);
+    /**
+     * Get the expanded state
+     *
+     * @returns {boolean} Whether this item is expanded
+     */
+    get expanded() {
+        return this._expanded;
     }
-  }
+
+    /**
+     * Set the expanded state
+     *
+     * @param {boolean} value - The new expanded state
+     */
+    set expanded(value) {
+        if (this._expanded !== value) {
+            this._expanded = value;
+            this.notify('expanded');
+        }
+    }
+
+    /**
+     * Update the UI to reflect the current selection state
+     *
+     * @private
+     */
+    _updateSelection() {
+        this.checkIcon.visible = this._selected;
+
+        if (this._selected)
+            this.add_style_pseudo_class('selected');
+        else
+            this.remove_style_pseudo_class('selected');
+    }
+
+    /**
+     * Override the activate method to emit the activate signal
+     * This allows the item to be activated by keyboard or mouse
+     *
+     * @param {Clutter.Event} event - The event that triggered the activation
+     */
+    activate(event) {
+        if (this._activatable)
+            this.emit('activate', event);
+    }
 });
 
 /**
  * Modal dialog for selecting Mullvad exit nodes
  *
  * @class MullvadExitNodeDialog
- * @extends ModalDialog.ModalDialog
+ * @augments ModalDialog.ModalDialog
  */
 export const MullvadExitNodeDialog = GObject.registerClass(
   class MullvadExitNodeDialog extends ModalDialog.ModalDialog {
-    /**
-     * Create a new MullvadExitNodeDialog
-     *
-     * @param {Array} mullvadNodes - Array of available Mullvad nodes
-     * @param {Object} tailscale - Tailscale instance to control exit node selection
-     */
-    _init(mullvadNodes, tailscale) {
-      super._init({
-        styleClass: 'mullvad-exit-node-dialog modal-dialog',
-        destroyOnClose: true,
-        shellReactive: true,
-        shouldFadeIn: true,
-        shouldFadeOut: true
-      });
+      /**
+       * Create a new MullvadExitNodeDialog
+       *
+       * @param {Array} mullvadNodes - Array of available Mullvad nodes
+       * @param {object} tailscale - Tailscale instance to control exit node selection
+       */
+      _init(mullvadNodes, tailscale) {
+          super._init({
+              styleClass: 'mullvad-exit-node-dialog modal-dialog',
+              destroyOnClose: true,
+              shellReactive: true,
+              shouldFadeIn: true,
+              shouldFadeOut: true,
+          });
 
-      this._initializeProperties(mullvadNodes, tailscale);
-      this._setDialogSize();
-      this._processNodeData();
-      this._buildUI();
-    }
-
-    /**
-     * Initialize dialog properties
-     *
-     * @param {Array} mullvadNodes - Array of available Mullvad nodes
-     * @param {Object} tailscale - Tailscale instance
-     * @private
-     */
-    _initializeProperties(mullvadNodes, tailscale) {
-      this._nodes = mullvadNodes;
-      this._tailscale = tailscale;
-      this._selectedItem = null;
-      this._searchQuery = '';
-      this._locationItems = [];
-    }
-
-    /**
-     * Set dialog size based on screen dimensions
-     * @private
-     */
-    _setDialogSize() {
-      const primaryMonitor = global.display.get_primary_monitor();
-      const monitorGeometry = global.display.get_monitor_geometry(primaryMonitor);
-      // Set width to 35% of screen width
-      this.contentLayout.width = Math.floor(monitorGeometry.width * 0.35);
-    }
-
-    /**
-     * Process node data to organize by location and find best nodes
-     * @private
-     */
-    _processNodeData() {
-      this._locationData = {};
-      this._groupNodesByLocation();
-      this._findBestNodesForLocations();
-      this._removeInvalidLocations();
-    }
-
-    /**
-     * Group nodes by city and country
-     * @private
-     */
-    _groupNodesByLocation() {
-      for (const node of this._nodes) {
-        const country = node.location?.Country || 'Unknown';
-        const city = node.location?.City || 'Unknown';
-        const countryCode = node.location?.CountryCode || '';
-        const locationKey = `${city} ${country}`;
-
-        if (!this._locationData[locationKey]) {
-          this._locationData[locationKey] = {
-            city,
-            country,
-            countryCode,
-            nodes: [],
-            bestNode: null
-          };
-        }
-
-        this._locationData[locationKey].nodes.push(node);
+          this._initializeProperties(mullvadNodes, tailscale);
+          this._setDialogSize();
+          this._processNodeData();
+          this._buildUI();
       }
-    }
 
-    /**
-     * Find the best node for each location and count online nodes
-     * @private
-     */
-    _findBestNodesForLocations() {
-      Object.values(this._locationData).forEach(location => {
-        const onlineNodes = location.nodes.filter(node => node.online);
-        location.nodeCount = onlineNodes.length;
+      /**
+       * Initialize dialog properties
+       *
+       * @param {Array} mullvadNodes - Array of available Mullvad nodes
+       * @param {object} tailscale - Tailscale instance
+       * @private
+       */
+      _initializeProperties(mullvadNodes, tailscale) {
+          this._nodes = mullvadNodes;
+          this._tailscale = tailscale;
+          this._selectedItem = null;
+          this._searchQuery = '';
+          this._locationItems = [];
+      }
 
-        if (onlineNodes.length > 0) {
-          location.bestNode = this._findBestNode(onlineNodes);
-        } else if (location.nodes.length > 0) {
-          // Fallback to any node if no online nodes
-          location.bestNode = location.nodes[0];
-        }
-      });
-    }
+      /**
+       * Set dialog size based on screen dimensions
+       *
+       * @private
+       */
+      _setDialogSize() {
+          const primaryMonitor = global.display.get_primary_monitor();
+          const monitorGeometry = global.display.get_monitor_geometry(primaryMonitor);
+          // Set width to 35% of screen width
+          this.contentLayout.width = Math.floor(monitorGeometry.width * 0.35);
+      }
 
-    /**
-     * Find the best node (the one with the lowest priority value)
-     *
-     * @param {Array} nodes - Array of nodes to search
-     * @returns {Object} The node with the lowest priority
-     * @private
-     */
-    _findBestNode(nodes) {
-      return nodes.sort((a, b) => {
-        const aPriority = a.location?.Priority || Number.MAX_SAFE_INTEGER;
-        const bPriority = b.location?.Priority || Number.MAX_SAFE_INTEGER;
-        return aPriority - bPriority;
-      })[0];
-    }
+      /**
+       * Process node data to organize by location and find best nodes
+       *
+       * @private
+       */
+      _processNodeData() {
+          this._locationData = {};
+          this._groupNodesByLocation();
+          this._findBestNodesForLocations();
+          this._removeInvalidLocations();
+      }
 
-    /**
-     * Remove locations with no best node or no online nodes
-     * @private
-     */
-    _removeInvalidLocations() {
-      Object.keys(this._locationData).forEach(key => {
-        if (!this._locationData[key].bestNode || this._locationData[key].nodeCount === 0) {
-          delete this._locationData[key];
-        }
-      });
-    }
+      /**
+       * Group nodes by city and country
+       *
+       * @private
+       */
+      _groupNodesByLocation() {
+          for (const node of this._nodes) {
+              const country = node.location?.Country || 'Unknown';
+              const city = node.location?.City || 'Unknown';
+              const countryCode = node.location?.CountryCode || '';
+              const locationKey = `${city} ${country}`;
 
-    /**
-     * Build the dialog UI components
-     * @private
-     */
-    _buildUI() {
-      this._createHeader();
-      this._createSearchBox();
-      this._createLocationsList();
-      this._setupEventHandlers();
-      this._populateLocationsList();
-    }
+              if (!this._locationData[locationKey]) {
+                  this._locationData[locationKey] = {
+                      city,
+                      country,
+                      countryCode,
+                      nodes: [],
+                      bestNode: null,
+                  };
+              }
 
-    /**
-     * Create the dialog header with title and close button
-     * @private
-     */
-    _createHeader() {
-      const headerBox = new St.BoxLayout({
-        style_class: 'mullvad-dialog-header',
-        vertical: false,
-        x_expand: true,
-        y_expand: false,
-        height: 28,
-        y_align: Clutter.ActorAlign.START
-      });
-
-      // Dialog title (center, bold)
-      const title = new St.Label({
-        style_class: 'mullvad-dialog-title title',
-        text: _('Select Exit Node'),
-        x_expand: true,
-        x_align: Clutter.ActorAlign.CENTER,
-        y_align: Clutter.ActorAlign.CENTER,
-        style: 'font-weight: bold;'
-      });
-      headerBox.add_child(title);
-
-      // Close button (right side)
-      const closeButton = new St.Button({
-        style_class: 'window-close',
-        x_align: Clutter.ActorAlign.END,
-        y_align: Clutter.ActorAlign.CENTER
-      });
-
-      const closeIcon = new St.Icon({
-        icon_name: 'window-close-symbolic',
-        style_class: 'system-status-icon'
-      });
-      closeButton.set_child(closeIcon);
-      closeButton.connect('clicked', this._onCancelClicked.bind(this));
-      headerBox.add_child(closeButton);
-
-      this.contentLayout.add_child(headerBox);
-    }
-
-    /**
-     * Create the search box for filtering locations
-     * @private
-     */
-    _createSearchBox() {
-      const searchBox = new St.BoxLayout({
-        style_class: 'mullvad-search-box',
-        vertical: false,
-        x_expand: true,
-        margin_top: 12,
-      });
-
-      this._searchEntry = new St.Entry({
-        style_class: 'mullvad-search-entry search-entry',
-        hint_text: _('Search by City or Country...'),
-        track_hover: true,
-        can_focus: true,
-        x_expand: true
-      });
-
-      // Add search icon
-      const searchIcon = new St.Icon({
-        icon_name: 'edit-find-symbolic',
-        style_class: 'search-entry-icon'
-      });
-      this._searchEntry.set_primary_icon(searchIcon);
-
-      // Add clear button
-      const clearIcon = new St.Icon({
-        icon_name: 'edit-clear-symbolic',
-        style_class: 'search-entry-icon'
-      });
-      this._searchEntry.set_secondary_icon(clearIcon);
-
-      searchBox.add_child(this._searchEntry);
-      this.contentLayout.add_child(searchBox);
-    }
-
-    /**
-     * Create the scrollable list view for locations
-     * @private
-     */
-    _createLocationsList() {
-      // Calculate height based on screen size
-      const primaryMonitor = global.display.get_primary_monitor();
-      const monitorHeight = global.display.get_monitor_geometry(primaryMonitor).height;
-      const listHeight = Math.floor(monitorHeight * 0.4); // 40% of screen height
-
-      // Scrollable list view
-      this._scrollView = new St.ScrollView({
-        style_class: 'mullvad-locations-scrollview',
-        x_expand: true,
-        y_expand: true,
-        y_align: Clutter.ActorAlign.START,
-        margin_top: 12,
-        height: listHeight,
-      });
-      this._scrollView.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
-
-      // List container
-      this._listBox = new St.BoxLayout({
-        style_class: 'mullvad-locations-list boxed-list',
-        vertical: true,
-        x_expand: true
-      });
-
-      this._scrollView.add_child(this._listBox);
-      this.contentLayout.add_child(this._scrollView);
-    }
-
-    /**
-     * Set up event handlers for the dialog
-     * @private
-     */
-    _setupEventHandlers() {
-      // Set initial focus to search entry
-      this.setInitialKeyFocus(this._searchEntry);
-
-      // Connect search query changed event
-      this._textChangedId = this._searchEntry.clutter_text.connect(
-        'text-changed',
-        this._onSearchQueryChanged.bind(this)
-      );
-
-      // Connect clear button clicked event
-      this._clearIconClickedId = this._searchEntry.connect(
-        'secondary-icon-clicked',
-        () => {
-          if (this._searchEntry && this._searchEntry.get_stage()) {
-            this._searchEntry.set_text('');
+              this._locationData[locationKey].nodes.push(node);
           }
-        }
-      );
-
-      // Add key binding for Escape key to close dialog
-      this.connect('key-press-event', (actor, event) => {
-        const symbol = event.get_key_symbol();
-        if (symbol === Clutter.KEY_Escape) {
-          this._onCancelClicked();
-          return Clutter.EVENT_STOP;
-        }
-        return Clutter.EVENT_PROPAGATE;
-      });
-    }
-
-    /**
-     * Populate the location list with filtered and sorted items
-     * @private
-     */
-    _populateLocationsList() {
-      this._clearList();
-
-      const filteredLocations = this._getFilteredAndSortedLocations();
-
-      if (filteredLocations.length === 0) {
-        this._showNoResultsMessage();
-        return;
       }
 
-      this._createLocationItems(filteredLocations);
-    }
+      /**
+       * Find the best node for each location and count online nodes
+       *
+       * @private
+       */
+      _findBestNodesForLocations() {
+          Object.values(this._locationData).forEach(location => {
+              const onlineNodes = location.nodes.filter(node => node.online);
+              location.nodeCount = onlineNodes.length;
 
-    /**
-     * Clear the list of existing items
-     * @private
-     */
-    _clearList() {
-      this._listBox.destroy_all_children();
-      this._locationItems = [];
-    }
-
-    /**
-     * Get locations filtered by search text and sorted alphabetically
-     * @returns {Array} Filtered and sorted location objects
-     * @private
-     */
-    _getFilteredAndSortedLocations() {
-      const locations = Object.values(this._locationData);
-
-      // Filter locations based on search text
-      const filteredLocations = this._filterLocations(locations);
-
-      // Sort locations alphabetically by country then city
-      return this._sortLocationsByCountryAndCity(filteredLocations);
-    }
-
-    /**
-     * Filter locations based on search query
-     * @param {Array} locations - Array of location objects
-     * @returns {Array} Filtered location objects
-     * @private
-     */
-    _filterLocations(locations) {
-      if (!this._searchQuery) {
-        return locations;
+              if (onlineNodes.length > 0) {
+                  location.bestNode = this._findBestNode(onlineNodes);
+              } else if (location.nodes.length > 0) {
+                  // Fallback to any node if no online nodes
+                  location.bestNode = location.nodes[0];
+              }
+          });
       }
 
-      const searchQuery = this._searchQuery.toLowerCase();
-      return locations.filter(location => {
-        const cityMatch = location.city.toLowerCase().includes(searchQuery);
-        const countryMatch = location.country.toLowerCase().includes(searchQuery);
-        return cityMatch || countryMatch;
-      });
-    }
+      /**
+       * Find the best node (the one with the lowest priority value)
+       *
+       * @param {Array} nodes - Array of nodes to search
+       * @returns {object} The node with the lowest priority
+       * @private
+       */
+      _findBestNode(nodes) {
+          return nodes.sort((a, b) => {
+              const aPriority = a.location?.Priority || Number.MAX_SAFE_INTEGER;
+              const bPriority = b.location?.Priority || Number.MAX_SAFE_INTEGER;
+              return aPriority - bPriority;
+          })[0];
+      }
 
-    /**
-     * Sort locations alphabetically by country then city
-     * @param {Array} locations - Array of location objects
-     * @returns {Array} Sorted location objects
-     * @private
-     */
-    _sortLocationsByCountryAndCity(locations) {
-      return [...locations].sort((a, b) => {
-        if (a.country !== b.country) {
-          return a.country.localeCompare(b.country);
-        }
-        return a.city.localeCompare(b.city);
-      });
-    }
+      /**
+       * Remove locations with no best node or no online nodes
+       *
+       * @private
+       */
+      _removeInvalidLocations() {
+          Object.keys(this._locationData).forEach(key => {
+              if (!this._locationData[key].bestNode || this._locationData[key].nodeCount === 0)
+                  delete this._locationData[key];
+          });
+      }
 
-    /**
-     * Show a message when no locations match the search
-     * @private
-     */
-    _showNoResultsMessage() {
-      const noResultsBox = new St.BoxLayout({
-        style_class: 'mullvad-no-results',
-        vertical: true,
-        x_align: Clutter.ActorAlign.CENTER,
-        y_align: Clutter.ActorAlign.CENTER
-      });
+      /**
+       * Build the dialog UI components
+       *
+       * @private
+       */
+      _buildUI() {
+          this._createHeader();
+          this._createSearchBox();
+          this._createLocationsList();
+          this._setupEventHandlers();
+          this._populateLocationsList();
+      }
 
-      const noResultsIcon = new St.Icon({
-        icon_name: 'dialog-information-symbolic',
-        icon_size: 32,
-        style_class: 'mullvad-no-results-icon'
-      });
-      noResultsBox.add_child(noResultsIcon);
+      /**
+       * Create the dialog header with title and close button
+       *
+       * @private
+       */
+      _createHeader() {
+          const headerBox = new St.BoxLayout({
+              style_class: 'mullvad-dialog-header',
+              vertical: false,
+              x_expand: true,
+              y_expand: false,
+              height: 28,
+              y_align: Clutter.ActorAlign.START,
+          });
 
-      const noResultsLabel = new St.Label({
-        style_class: 'mullvad-no-results-label heading',
-        text: _('No locations found')
-      });
-      noResultsBox.add_child(noResultsLabel);
+          // Dialog title (center, bold)
+          const title = new St.Label({
+              style_class: 'mullvad-dialog-title title',
+              text: _('Select Exit Node'),
+              x_expand: true,
+              x_align: Clutter.ActorAlign.CENTER,
+              y_align: Clutter.ActorAlign.CENTER,
+              style: 'font-weight: bold;',
+          });
+          headerBox.add_child(title);
 
-      this._listBox.add_child(noResultsBox);
-    }
+          // Close button (right side)
+          const closeButton = new St.Button({
+              style_class: 'window-close',
+              x_align: Clutter.ActorAlign.END,
+              y_align: Clutter.ActorAlign.CENTER,
+          });
 
-    /**
-     * Create location items for each location and add them to the list
-     * @param {Array} locations - Array of location objects
-     * @private
-     */
-    _createLocationItems(locations) {
-      locations.forEach(location => {
-        const locationItem = new MullvadLocationItem(
-          location.city,
-          location.country,
-          location.nodeCount,
-          location.bestNode,
-          location.nodes,
-          location.countryCode
-        );
+          const closeIcon = new St.Icon({
+              icon_name: 'window-close-symbolic',
+              style_class: 'system-status-icon',
+          });
+          closeButton.set_child(closeIcon);
+          closeButton.connect('clicked', this._onCancelClicked.bind(this));
+          headerBox.add_child(closeButton);
 
-        // Check if this is the current exit node
-        if (this._tailscale.exit_node === location.bestNode.id) {
-          locationItem.selected = true;
-          this._selectedItem = locationItem;
-        }
+          this.contentLayout.add_child(headerBox);
+      }
 
-        // Connect activation handler
-        locationItem.connect('activate', () => {
-          this._onLocationItemClicked(locationItem);
-        });
+      /**
+       * Create the search box for filtering locations
+       *
+       * @private
+       */
+      _createSearchBox() {
+          const searchBox = new St.BoxLayout({
+              style_class: 'mullvad-search-box',
+              vertical: false,
+              x_expand: true,
+              margin_top: 12,
+          });
 
-        // Connect expand-toggled handler
-        locationItem.connect('expand-toggled', (item, expanded) => {
-          this._onLocationItemExpandToggled(locationItem, expanded);
-        });
+          this._searchEntry = new St.Entry({
+              style_class: 'mullvad-search-entry search-entry',
+              hint_text: _('Search by City or Country...'),
+              track_hover: true,
+              can_focus: true,
+              x_expand: true,
+          });
 
-        // Make the item activatable
-        locationItem._activatable = true;
+          // Add search icon
+          const searchIcon = new St.Icon({
+              icon_name: 'edit-find-symbolic',
+              style_class: 'search-entry-icon',
+          });
+          this._searchEntry.set_primary_icon(searchIcon);
 
-        this._listBox.add_child(locationItem);
-        this._locationItems.push(locationItem);
-      });
-    }
+          // Add clear button
+          const clearIcon = new St.Icon({
+              icon_name: 'edit-clear-symbolic',
+              style_class: 'search-entry-icon',
+          });
+          this._searchEntry.set_secondary_icon(clearIcon);
 
-    /**
-     * Handle location item expand/collapse event
-     *
-     * @param {MullvadLocationItem} locationItem - The location item that was expanded/collapsed
-     * @param {boolean} expanded - Whether the item is expanded
-     * @private
-     */
-    _onLocationItemExpandToggled(locationItem, expanded) {
+          searchBox.add_child(this._searchEntry);
+          this.contentLayout.add_child(searchBox);
+      }
+
+      /**
+       * Create the scrollable list view for locations
+       *
+       * @private
+       */
+      _createLocationsList() {
+      // Calculate height based on screen size
+          const primaryMonitor = global.display.get_primary_monitor();
+          const monitorHeight = global.display.get_monitor_geometry(primaryMonitor).height;
+          const listHeight = Math.floor(monitorHeight * 0.4); // 40% of screen height
+
+          // Scrollable list view
+          this._scrollView = new St.ScrollView({
+              style_class: 'mullvad-locations-scrollview',
+              x_expand: true,
+              y_expand: true,
+              y_align: Clutter.ActorAlign.START,
+              margin_top: 12,
+              height: listHeight,
+          });
+          this._scrollView.set_policy(St.PolicyType.NEVER, St.PolicyType.AUTOMATIC);
+
+          // List container
+          this._listBox = new St.BoxLayout({
+              style_class: 'mullvad-locations-list boxed-list',
+              vertical: true,
+              x_expand: true,
+          });
+
+          this._scrollView.add_child(this._listBox);
+          this.contentLayout.add_child(this._scrollView);
+      }
+
+      /**
+       * Set up event handlers for the dialog
+       *
+       * @private
+       */
+      _setupEventHandlers() {
+      // Set initial focus to search entry
+          this.setInitialKeyFocus(this._searchEntry);
+
+          // Connect search query changed event
+          this._textChangedId = this._searchEntry.clutter_text.connect(
+              'text-changed',
+              this._onSearchQueryChanged.bind(this)
+          );
+
+          // Connect clear button clicked event
+          this._clearIconClickedId = this._searchEntry.connect(
+              'secondary-icon-clicked',
+              () => {
+                  if (this._searchEntry && this._searchEntry.get_stage())
+                      this._searchEntry.set_text('');
+              }
+          );
+
+          // Add key binding for Escape key to close dialog
+          this.connect('key-press-event', (_actor, event) => {
+              const symbol = event.get_key_symbol();
+              if (symbol === Clutter.KEY_Escape) {
+                  this._onCancelClicked();
+                  return Clutter.EVENT_STOP;
+              }
+              return Clutter.EVENT_PROPAGATE;
+          });
+      }
+
+      /**
+       * Populate the location list with filtered and sorted items
+       *
+       * @private
+       */
+      _populateLocationsList() {
+          this._clearList();
+
+          const filteredLocations = this._getFilteredAndSortedLocations();
+
+          if (filteredLocations.length === 0) {
+              this._showNoResultsMessage();
+              return;
+          }
+
+          this._createLocationItems(filteredLocations);
+      }
+
+      /**
+       * Clear the list of existing items
+       *
+       * @private
+       */
+      _clearList() {
+          this._listBox.destroy_all_children();
+          this._locationItems = [];
+      }
+
+      /**
+       * Get locations filtered by search text and sorted alphabetically
+       *
+       * @returns {Array} Filtered and sorted location objects
+       * @private
+       */
+      _getFilteredAndSortedLocations() {
+          const locations = Object.values(this._locationData);
+
+          // Filter locations based on search text
+          const filteredLocations = this._filterLocations(locations);
+
+          // Sort locations alphabetically by country then city
+          return this._sortLocationsByCountryAndCity(filteredLocations);
+      }
+
+      /**
+       * Filter locations based on search query
+       *
+       * @param {Array} locations - Array of location objects
+       * @returns {Array} Filtered location objects
+       * @private
+       */
+      _filterLocations(locations) {
+          if (!this._searchQuery)
+              return locations;
+
+
+          const searchQuery = this._searchQuery.toLowerCase();
+          return locations.filter(location => {
+              const cityMatch = location.city.toLowerCase().includes(searchQuery);
+              const countryMatch = location.country.toLowerCase().includes(searchQuery);
+              return cityMatch || countryMatch;
+          });
+      }
+
+      /**
+       * Sort locations alphabetically by country then city
+       *
+       * @param {Array} locations - Array of location objects
+       * @returns {Array} Sorted location objects
+       * @private
+       */
+      _sortLocationsByCountryAndCity(locations) {
+          return [...locations].sort((a, b) => {
+              if (a.country !== b.country)
+                  return a.country.localeCompare(b.country);
+
+              return a.city.localeCompare(b.city);
+          });
+      }
+
+      /**
+       * Show a message when no locations match the search
+       *
+       * @private
+       */
+      _showNoResultsMessage() {
+          const noResultsBox = new St.BoxLayout({
+              style_class: 'mullvad-no-results',
+              vertical: true,
+              x_align: Clutter.ActorAlign.CENTER,
+              y_align: Clutter.ActorAlign.CENTER,
+          });
+
+          const noResultsIcon = new St.Icon({
+              icon_name: 'dialog-information-symbolic',
+              icon_size: 32,
+              style_class: 'mullvad-no-results-icon',
+          });
+          noResultsBox.add_child(noResultsIcon);
+
+          const noResultsLabel = new St.Label({
+              style_class: 'mullvad-no-results-label heading',
+              text: _('No locations found'),
+          });
+          noResultsBox.add_child(noResultsLabel);
+
+          this._listBox.add_child(noResultsBox);
+      }
+
+      /**
+       * Create location items for each location and add them to the list
+       *
+       * @param {Array} locations - Array of location objects
+       * @private
+       */
+      _createLocationItems(locations) {
+          locations.forEach(location => {
+              const locationItem = new MullvadLocationItem(
+                  location.city,
+                  location.country,
+                  location.nodeCount,
+                  location.bestNode,
+                  location.nodes,
+                  location.countryCode
+              );
+
+              // Check if this is the current exit node
+              if (this._tailscale.exit_node === location.bestNode.id) {
+                  locationItem.selected = true;
+                  this._selectedItem = locationItem;
+              }
+
+              // Connect activation handler
+              locationItem.connect('activate', () => {
+                  this._onLocationItemClicked(locationItem);
+              });
+
+              // Connect expand-toggled handler
+              locationItem.connect('expand-toggled', (_item, expanded) => {
+                  this._onLocationItemExpandToggled(locationItem, expanded);
+              });
+
+              // Make the item activatable
+              locationItem._activatable = true;
+
+              this._listBox.add_child(locationItem);
+              this._locationItems.push(locationItem);
+          });
+      }
+
+      /**
+       * Handle location item expand/collapse event
+       *
+       * @param {MullvadLocationItem} locationItem - The location item that was expanded/collapsed
+       * @param {boolean} expanded - Whether the item is expanded
+       * @private
+       */
+      _onLocationItemExpandToggled(locationItem, expanded) {
       // Remove any existing node items for this location
-      this._removeNodeItemsForLocation(locationItem);
+          this._removeNodeItemsForLocation(locationItem);
 
-      if (expanded) {
-        // Create and add node items for this location
-        this._createNodeItemsForLocation(locationItem);
+          if (expanded) {
+              // Create and add node items for this location
+              this._createNodeItemsForLocation(locationItem);
+          }
       }
-    }
 
-    /**
-     * Remove node items for a location
-     *
-     * @param {MullvadLocationItem} locationItem - The location item
-     * @private
-     */
-    _removeNodeItemsForLocation(locationItem) {
+      /**
+       * Remove node items for a location
+       *
+       * @param {MullvadLocationItem} locationItem - The location item
+       * @private
+       */
+      _removeNodeItemsForLocation(locationItem) {
       // Find the index of the location item
-      const locationIndex = this._listBox.get_children().indexOf(locationItem);
-      if (locationIndex === -1) return;
+          const locationIndex = this._listBox.get_children().indexOf(locationItem);
+          if (locationIndex === -1)
+              return;
 
-      // Get all children after this location item
-      const children = this._listBox.get_children();
+          // Get all children after this location item
+          const children = this._listBox.get_children();
 
-      // Collect all node items to remove
-      const nodesToRemove = [];
-      for (let i = locationIndex + 1; i < children.length; i++) {
-        const child = children[i];
-        if (child.constructor.name === 'MullvadNodeItem') {
-          nodesToRemove.push(child);
-        } else {
-          // We've hit another location item, stop collecting
-          break;
-        }
+          // Collect all node items to remove
+          const nodesToRemove = [];
+          for (let i = locationIndex + 1; i < children.length; i++) {
+              const child = children[i];
+              if (child.constructor.name === 'MullvadNodeItem') {
+                  nodesToRemove.push(child);
+              } else {
+                  // We've hit another location item, stop collecting
+                  break;
+              }
+          }
+
+          // Remove all collected node items
+          for (const child of nodesToRemove) {
+              if (child.get_parent() === this._listBox)
+                  this._listBox.remove_child(child);
+          }
       }
 
-      // Remove all collected node items
-      for (const child of nodesToRemove) {
-        if (child.get_parent() === this._listBox) {
-          this._listBox.remove_child(child);
-        }
-      }
-    }
-
-    /**
-     * Create and add node items for a location
-     *
-     * @param {MullvadLocationItem} locationItem - The location item
-     * @private
-     */
-    _createNodeItemsForLocation(locationItem) {
+      /**
+       * Create and add node items for a location
+       *
+       * @param {MullvadLocationItem} locationItem - The location item
+       * @private
+       */
+      _createNodeItemsForLocation(locationItem) {
       // Find the index of the location item
-      const locationIndex = this._listBox.get_children().indexOf(locationItem);
-      if (locationIndex === -1) return;
+          const locationIndex = this._listBox.get_children().indexOf(locationItem);
+          if (locationIndex === -1)
+              return;
 
-      // Filter online nodes and sort by priority (lowest first)
-      const onlineNodes = locationItem.nodes
+          // Filter online nodes and sort by priority (lowest first)
+          const onlineNodes = locationItem.nodes
         .filter(node => node.online)
         .sort((a, b) => {
-          const aPriority = a.location?.Priority || Number.MAX_SAFE_INTEGER;
-          const bPriority = b.location?.Priority || Number.MAX_SAFE_INTEGER;
-          return aPriority - bPriority;
+            const aPriority = a.location?.Priority || Number.MAX_SAFE_INTEGER;
+            const bPriority = b.location?.Priority || Number.MAX_SAFE_INTEGER;
+            return aPriority - bPriority;
         });
 
-      // Create a node item for each node and insert after the location item
-      onlineNodes.forEach((node, i) => {
-        const nodeItem = new MullvadNodeItem(
-          node.name,
-          node.id,
-          node.location?.Priority || 0,
-          node.id === this._tailscale.exit_node
-        );
+          // Create a node item for each node and insert after the location item
+          onlineNodes.forEach((node, i) => {
+              const nodeItem = new MullvadNodeItem(
+                  node.name,
+                  node.id,
+                  node.location?.Priority || 0,
+                  node.id === this._tailscale.exit_node
+              );
 
-        // Connect activation handler
-        nodeItem.connect('activate', () => {
-          this._onNodeItemClicked(nodeItem);
-        });
+              // Connect activation handler
+              nodeItem.connect('activate', () => {
+                  this._onNodeItemClicked(nodeItem);
+              });
 
-        // Make the item activatable
-        nodeItem._activatable = true;
+              // Make the item activatable
+              nodeItem._activatable = true;
 
-        // Insert after the location item and any previously added node items
-        this._listBox.insert_child_at_index(nodeItem, locationIndex + 1 + i);
-      });
-    }
+              // Insert after the location item and any previously added node items
+              this._listBox.insert_child_at_index(nodeItem, locationIndex + 1 + i);
+          });
+      }
 
-    /**
-     * Handle node item click event
-     *
-     * @param {MullvadNodeItem} nodeItem - The clicked node item
-     * @private
-     */
-    _onNodeItemClicked(nodeItem) {
+      /**
+       * Handle node item click event
+       *
+       * @param {MullvadNodeItem} nodeItem - The clicked node item
+       * @private
+       */
+      _onNodeItemClicked(nodeItem) {
       // Deselect previous item if any
-      if (this._selectedItem) {
-        this._selectedItem.selected = false;
+          if (this._selectedItem)
+              this._selectedItem.selected = false;
+
+
+          // Select the clicked item
+          nodeItem.selected = true;
+          this._selectedItem = nodeItem;
+
+          // Connect to the selected node and close the dialog
+          this._tailscale.exit_node = nodeItem.nodeId;
+          this.close();
       }
 
-      // Select the clicked item
-      nodeItem.selected = true;
-      this._selectedItem = nodeItem;
-
-      // Connect to the selected node and close the dialog
-      this._tailscale.exit_node = nodeItem.nodeId;
-      this.close();
-    }
-
-    /**
-     * Handle location item click event
-     *
-     * @param {MullvadLocationItem} locationItem - The clicked location item
-     * @private
-     */
-    _onLocationItemClicked(locationItem) {
+      /**
+       * Handle location item click event
+       *
+       * @param {MullvadLocationItem} locationItem - The clicked location item
+       * @private
+       */
+      _onLocationItemClicked(locationItem) {
       // Deselect previous item if any
-      if (this._selectedItem && this._selectedItem !== locationItem) {
-        this._selectedItem.selected = false;
+          if (this._selectedItem && this._selectedItem !== locationItem)
+              this._selectedItem.selected = false;
+
+
+          // Select the clicked item
+          locationItem.selected = true;
+          this._selectedItem = locationItem;
+
+          // Connect to the selected node and close the dialog
+          if (this._selectedItem?.bestNode) {
+              this._tailscale.exit_node = this._selectedItem.bestNode.id;
+              this.close();
+          }
       }
 
-      // Select the clicked item
-      locationItem.selected = true;
-      this._selectedItem = locationItem;
-
-      // Connect to the selected node and close the dialog
-      if (this._selectedItem?.bestNode) {
-        this._tailscale.exit_node = this._selectedItem.bestNode.id;
-        this.close();
+      /**
+       * Handle search query changed event
+       *
+       * @private
+       */
+      _onSearchQueryChanged() {
+          this._searchQuery = this._searchEntry.get_text() || '';
+          this._populateLocationsList();
       }
-    }
 
-    /**
-     * Handle search query changed event
-     * @private
-     */
-    _onSearchQueryChanged() {
-      this._searchQuery = this._searchEntry.get_text() || '';
-      this._populateLocationsList();
-    }
-
-    /**
-     * Handle cancel button click event
-     * @private
-     */
-    _onCancelClicked() {
-      this.close();
-    }
+      /**
+       * Handle cancel button click event
+       *
+       * @private
+       */
+      _onCancelClicked() {
+          this.close();
+      }
   }
 );
 
@@ -966,21 +992,21 @@ export const MullvadExitNodeDialog = GObject.registerClass(
  * Create a menu item for selecting Mullvad exit nodes
  *
  * @param {Array} availableMullvadNodes - Array of available Mullvad nodes
- * @param {Object} tailscale - Tailscale instance to control exit node selection
+ * @param {object} tailscale - Tailscale instance to control exit node selection
  * @returns {PopupMenu.PopupMenuItem|null} The menu item or null if no nodes available
  */
 export function createMullvadExitNodeButton(availableMullvadNodes, tailscale) {
-  if (!availableMullvadNodes || availableMullvadNodes.length === 0) {
-    return null;
-  }
+    if (!availableMullvadNodes || availableMullvadNodes.length === 0)
+        return null;
 
-  const mullvadButtonItem = new PopupMenu.PopupMenuItem(_("Mullvad Exit Nodes"));
-  mullvadButtonItem.connect('activate', () => {
-    const dialog = new MullvadExitNodeDialog(availableMullvadNodes, tailscale);
-    dialog.open();
-  });
 
-  return mullvadButtonItem;
+    const mullvadButtonItem = new PopupMenu.PopupMenuItem(_('Mullvad Exit Nodes'));
+    mullvadButtonItem.connect('activate', () => {
+        const dialog = new MullvadExitNodeDialog(availableMullvadNodes, tailscale);
+        dialog.open();
+    });
+
+    return mullvadButtonItem;
 }
 
 /**
@@ -990,12 +1016,12 @@ export function createMullvadExitNodeButton(availableMullvadNodes, tailscale) {
  * @returns {Array} Filtered array containing only Mullvad nodes
  */
 export function filterMullvadNodes(nodes) {
-  if (!nodes || !Array.isArray(nodes)) {
-    return [];
-  }
+    if (!nodes || !Array.isArray(nodes))
+        return [];
 
-  return nodes.filter(node =>
-    node.mullvad === true &&
+
+    return nodes.filter(node =>
+        node.mullvad === true &&
     node.online === true
-  );
+    );
 }

--- a/tailscale-gnome-qs@tailscale-qs.github.io/tailscale.js
+++ b/tailscale-gnome-qs@tailscale-qs.github.io/tailscale.js
@@ -1,415 +1,420 @@
-import GLib from "gi://GLib";
-import GObject from "gi://GObject";
-import Gio from "gi://Gio";
-import Soup from "gi://Soup?version=3.0";
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import Soup from 'gi://Soup?version=3.0';
 
 class TailscaleApiClient {
-  constructor() {
-    const address = new Gio.UnixSocketAddress({
-      path: "/var/run/tailscale/tailscaled.sock",
-    });
-    this.session = new Soup.Session({
-      "remote-connectable": address,
-      "timeout": 0,
-      "idle-timeout": 0,
-    });
-    this.encoder = new TextEncoder();
-    this.decoder = new TextDecoder();
-  }
+    constructor() {
+        const address = new Gio.UnixSocketAddress({
+            path: '/var/run/tailscale/tailscaled.sock',
+        });
+        this.session = new Soup.Session({
+            'remote-connectable': address,
+            'timeout': 0,
+            'idle-timeout': 0,
+        });
+        this.encoder = new TextEncoder();
+        this.decoder = new TextDecoder();
+    }
 
-  async* stream(method, path, cancellable) {
-    const message = Soup.Message.new(method, `http://local-tailscaled.sock${path}`);
+    async* stream(method, path, cancellable) {
+        const message = Soup.Message.new(method, `http://local-tailscaled.sock${path}`);
 
-    const base_stream = this.session.send(message, null);
-    const stream = new Gio.DataInputStream({ base_stream });
-    try {
-      const content_type = message.response_headers.get_one("Content-Type");
-      while (true) {
-        Gio._promisify(Gio.DataInputStream.prototype, "read_line_async");
-        const [_response, length] = await stream.read_line_async(GLib.PRIORITY_DEFAULT, cancellable);
-        if (length == 0) {
-          break;
+        const baseStream = this.session.send(message, null);
+        const stream = new Gio.DataInputStream({base_stream: baseStream});
+        try {
+            const contentType = message.response_headers.get_one('Content-Type');
+            while (true) {
+                Gio._promisify(Gio.DataInputStream.prototype, 'read_line_async');
+                // eslint-disable-next-line no-await-in-loop
+                const [_response, length] = await stream.read_line_async(GLib.PRIORITY_DEFAULT, cancellable);
+                if (length === 0)
+                    break;
+
+                const response = this.decoder.decode(_response);
+                yield contentType === 'application/json' ? JSON.parse(response) : response;
+            }
+        } finally {
+            stream.close(null);
         }
-        const response = this.decoder.decode(_response);
-        yield content_type == "application/json" ? JSON.parse(response) : response;
-      }
-    } finally {
-      stream.close(null);
-    }
-  }
-
-  async request(method, path, body = null) {
-    const message = Soup.Message.new(method, `http://local-tailscaled.sock${path}`);
-    if (body) {
-      const bytes = this.encoder.encode(JSON.stringify(body));
-      message.set_request_body_from_bytes("application/json", new GLib.Bytes(bytes));
     }
 
-    Gio._promisify(Soup.Session.prototype, "send_and_read_async");
-    const response_bytes = await this.session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
-    const response = this.decoder.decode(response_bytes.get_data());
-    const content_type = message.response_headers.get_one("Content-Type");
-    return content_type == "application/json" ? JSON.parse(response) : response
-  }
+    async request(method, path, body = null) {
+        const message = Soup.Message.new(method, `http://local-tailscaled.sock${path}`);
+        if (body) {
+            const bytes = this.encoder.encode(JSON.stringify(body));
+            message.set_request_body_from_bytes('application/json', new GLib.Bytes(bytes));
+        }
+
+        Gio._promisify(Soup.Session.prototype, 'send_and_read_async');
+        const responseBytes = await this.session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
+        const response = this.decoder.decode(responseBytes.get_data());
+        const contentType = message.response_headers.get_one('Content-Type');
+        return contentType === 'application/json' ? JSON.parse(response) : response;
+    }
 }
 
 export const Tailscale = GObject.registerClass(
-  {
-    Properties: {
-      "running": GObject.ParamSpec.boolean(
-        "running", "", "",
-        GObject.ParamFlags.READWRITE,
-        false
-      ),
-      "accept-dns": GObject.ParamSpec.boolean(
-        "accept-dns", "", "",
-        GObject.ParamFlags.READWRITE,
-        false
-      ),
-      "accept-routes": GObject.ParamSpec.boolean(
-        "accept-routes", "", "",
-        GObject.ParamFlags.READWRITE,
-        false
-      ),
-      "allow-lan-access": GObject.ParamSpec.boolean(
-        "allow-lan-access", "", "",
-        GObject.ParamFlags.READWRITE,
-        false
-      ),
-      "shields-up": GObject.ParamSpec.boolean(
-        "shields-up", "", "",
-        GObject.ParamFlags.READWRITE,
-        false
-      ),
-      "ssh": GObject.ParamSpec.boolean(
-        "ssh", "", "",
-        GObject.ParamFlags.READWRITE,
-        false
-      ),
-      "exit-node": GObject.ParamSpec.string(
-        "exit-node", "", "",
-        GObject.ParamFlags.READWRITE,
-        ""
-      ),
-      "exit-node-name": GObject.ParamSpec.string(
-        "exit-node-name", "", "",
-        GObject.ParamFlags.READABLE,
-        ""
-      ),
-      "nodes": GObject.ParamSpec.jsobject(
-        "nodes", "", "",
-        GObject.ParamFlags.READABLE,
-        []
-      ),
-      "profiles": GObject.ParamSpec.jsobject(
-        "profiles", "", "",
-        GObject.ParamFlags.READABLE,
-        []
-      ),
+    {
+        Properties: {
+            'running': GObject.ParamSpec.boolean(
+                'running', '', '',
+                GObject.ParamFlags.READWRITE,
+                false
+            ),
+            'accept-dns': GObject.ParamSpec.boolean(
+                'accept-dns', '', '',
+                GObject.ParamFlags.READWRITE,
+                false
+            ),
+            'accept-routes': GObject.ParamSpec.boolean(
+                'accept-routes', '', '',
+                GObject.ParamFlags.READWRITE,
+                false
+            ),
+            'allow-lan-access': GObject.ParamSpec.boolean(
+                'allow-lan-access', '', '',
+                GObject.ParamFlags.READWRITE,
+                false
+            ),
+            'shields-up': GObject.ParamSpec.boolean(
+                'shields-up', '', '',
+                GObject.ParamFlags.READWRITE,
+                false
+            ),
+            'ssh': GObject.ParamSpec.boolean(
+                'ssh', '', '',
+                GObject.ParamFlags.READWRITE,
+                false
+            ),
+            'exit-node': GObject.ParamSpec.string(
+                'exit-node', '', '',
+                GObject.ParamFlags.READWRITE,
+                ''
+            ),
+            'exit-node-name': GObject.ParamSpec.string(
+                'exit-node-name', '', '',
+                GObject.ParamFlags.READABLE,
+                ''
+            ),
+            'nodes': GObject.ParamSpec.jsobject(
+                'nodes', '', '',
+                GObject.ParamFlags.READABLE,
+                []
+            ),
+            'profiles': GObject.ParamSpec.jsobject(
+                'profiles', '', '',
+                GObject.ParamFlags.READABLE,
+                []
+            ),
+        },
     },
-  },
-  class Tailscale extends GObject.Object {
-    _init() {
-      super._init();
-      this._client = new TailscaleApiClient();
-      this._running = false;
-      this._dns = false;
-      this._routes = false;
-      this._allow_lan_access = false;
-      this._shields_up = false;
-      this._ssh = false;
-      this._exit_node = "";
-      this._exit_node_name = null;
-      this._nodes = [];
-      this._profiles = [];
-      this._cancelable = new Gio.Cancellable();
-      this._timeouts = [];
-      this._listen();
-    }
+    class Tailscale extends GObject.Object {
+        _init() {
+            super._init();
+            this._client = new TailscaleApiClient();
+            this._running = false;
+            this._dns = false;
+            this._routes = false;
+            this._allowLanAccess = false;
+            this._shields_up = false;
+            this._ssh = false;
+            this._exitNode = '';
+            this._exitNodeName = null;
+            this._nodes = [];
+            this._profiles = [];
+            this._cancelable = new Gio.Cancellable();
+            this._timeouts = [];
+            this._listen();
+        }
 
-    destroy() {
-      this._cancelable.cancel();
-      this._client.session.abort();
-      this._timeouts.forEach(id => GLib.Source.remove(id));
-      this._timeouts = [];
-    }
+        destroy() {
+            this._cancelable.cancel();
+            this._client.session.abort();
+            this._timeouts.forEach(id => GLib.Source.remove(id));
+            this._timeouts = [];
+        }
 
-    _process_running(prefs) {
-      const running = prefs.WantRunning;
-      if (running != this._running) {
-        this._running = running;
-        this.notify("running");
-      }
-    }
+        _processRunning(prefs) {
+            const running = prefs.WantRunning;
+            if (running !== this._running) {
+                this._running = running;
+                this.notify('running');
+            }
+        }
 
-    _process_nodes(prefs, peers) {
-      const nodes = peers
+        _processNodes(prefs, peers) {
+            const nodes = peers
         .map(peer => {
-          const node = {
-            id: peer.ID,
-            name: peer.DNSName.split(".")[0],
-            os: peer.OS,
-            exit_node: peer.ID == prefs.ExitNodeID,
-            exit_node_option: peer.ExitNodeOption,
-            online: peer.Online,
-            ips: peer.TailscaleIPs,
-            mullvad: peer.Tags?.includes("tag:mullvad-exit-node") || false,
-            location: peer.Location,
-          };
-          return node;
+            const node = {
+                id: peer.ID,
+                name: peer.DNSName.split('.')[0],
+                os: peer.OS,
+                exit_node: peer.ID === prefs.ExitNodeID,
+                exit_node_option: peer.ExitNodeOption,
+                online: peer.Online,
+                ips: peer.TailscaleIPs,
+                mullvad: peer.Tags?.includes('tag:mullvad-exit-node') || false,
+                location: peer.Location,
+            };
+            return node;
         })
         .sort((a, b) =>
-          (b.exit_node - a.exit_node)
-          || (b.online - a.online)
-          || (b.exit_node_option - a.exit_node_option)
-          || a.name.localeCompare(b.name)
+            (b.exit_node - a.exit_node) ||
+          (b.online - a.online) ||
+          (b.exit_node_option - a.exit_node_option) ||
+          a.name.localeCompare(b.name)
         );
 
-      if (JSON.stringify(nodes) != JSON.stringify(this._nodes)) {
-        this._nodes = nodes;
-        this.notify("nodes");
-      }
-    }
-
-    _process_exit_node(prefs) {
-      const exit_node_id = prefs.ExitNodeID;
-      if (exit_node_id != this._exit_node) {
-        this._exit_node = exit_node_id;
-        this.notify("exit-node");
-        const exitNodePeer = this._peers.find(peer => peer.ID === exit_node_id);
-        this._exit_node_name = exitNodePeer ? exitNodePeer.DNSName.split(".")[0] : null;
-        this.notify("exit-node-name");
-      }
-    }
-
-    _process_dns(prefs) {
-      const accept_dns = prefs.CorpDNS;
-      if (accept_dns != this._dns) {
-        this._dns = accept_dns;
-        this.notify("accept-dns");
-      }
-    }
-
-    _process_routes(prefs) {
-      const accept_routes = prefs.RouteAll;
-      if (accept_routes != this._routes) {
-        this._routes = accept_routes;
-        this.notify("accept-routes");
-      }
-    }
-
-    _process_lan(prefs) {
-      const allow_lan_access = prefs.ExitNodeAllowLANAccess;
-      if (allow_lan_access != this._allow_lan_access) {
-        this._allow_lan_access = allow_lan_access;
-        this.notify("allow-lan-access");
-      }
-    }
-
-    _process_shields(prefs) {
-      const shields_up = prefs.ShieldsUp;
-      if (shields_up != this._shields_up) {
-        this._shields_up = shields_up;
-        this.notify("shields-up");
-      }
-    }
-
-    _process_ssh(prefs) {
-      const ssh = prefs.RunSSH;
-      if (ssh != this._ssh) {
-        this._ssh = ssh;
-        this.notify("ssh");
-      }
-    }
-
-    get running() {
-      return this._running;
-    }
-
-    set running(value) {
-      if (this.running === value)
-        return;
-
-      this._update_prefs({ WantRunning: value });
-    }
-
-    get accept_dns() {
-      return this._dns;
-    }
-
-    set accept_dns(value) {
-      if (this.accept_dns === value)
-        return;
-
-      this._update_prefs({ CorpDNS: value });
-    }
-
-    get accept_routes() {
-      return this._routes;
-    }
-
-    set accept_routes(value) {
-      if (this.accept_routes === value)
-        return;
-
-      this._update_prefs({ RouteAll: value });
-    }
-
-    get allow_lan_access() {
-      return this._allow_lan_access;
-    }
-
-    set allow_lan_access(value) {
-      if (this.allow_lan_access === value)
-        return;
-
-      this._update_prefs({ ExitNodeAllowLANAccess: value });
-    }
-
-    get shields_up() {
-      return this._shields_up;
-    }
-
-    set shields_up(value) {
-      if (this.shields_up === value)
-        return;
-
-      this._update_prefs({ ShieldsUp: value });
-    }
-
-    get ssh() {
-      return this._ssh;
-    }
-
-    set ssh(value) {
-      if (this.ssh === value)
-        return;
-
-      this._update_prefs({ RunSSH: value });
-    }
-
-    get exit_node() {
-      return this._exit_node;
-    }
-
-    set exit_node(value) {
-      if (this.exit_node === value)
-        return;
-
-      this._update_prefs({ ExitNodeID: value });
-    }
-
-    get exit_node_name() {
-      return this._exit_node_name;
-    }
-
-    get nodes() {
-      return this._nodes;
-    }
-
-    get profiles() {
-      return this._profiles;
-    }
-
-    set profiles(value) {
-      this._update_profile(value);
-    }
-
-    async _listen() {
-      const delay = (delay) => new Promise(resolve => {
-        const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
-          const index = this._timeouts.indexOf(id);
-          if (index > -1) this._timeouts.splice(index, 1);
-          resolve();
-          return GLib.SOURCE_REMOVE;
-        });
-        this._timeouts.push(id);
-      });
-
-      while (true) {
-        try {
-          const status = await this._client.request("GET", "/localapi/v0/status")
-          this._peers = Object.values(status.Peer || {});
-          this._prefs = await this._client.request("GET", "/localapi/v0/prefs")
-          this._profiles = await this._client.request("GET", "/localapi/v0/profiles/")
-          this.notify("profiles");
-          this._parse_response();
-
-          for await (const update of this._client.stream("GET", "/localapi/v0/watch-ipn-bus", this._cancelable)) {
-            let should_update = false;
-            if (update.Prefs) {
-              this._prefs = update.Prefs;
-              should_update = true;
+            if (JSON.stringify(nodes) !== JSON.stringify(this._nodes)) {
+                this._nodes = nodes;
+                this.notify('nodes');
             }
-            if (update.NetMap) {
-              this._peers = update.NetMap.Peers.map(peer => ({
-                ID: peer.StableID,
-                DNSName: peer.Name,
-                OS: peer.Hostinfo.OS,
-                ExitNodeOption: peer.AllowedIPs?.includes("0.0.0.0/0"),
-                Online: peer.Online,
-                TailscaleIPs: peer.Addresses.map(address => address.split("/")[0]),
-                Tags: peer.Tags,
-                Location: peer.Hostinfo.Location
-              }));
-              should_update = true;
-            }
-            if (should_update) {
-              this._parse_response();
-            }
-          }
-        } catch (error) {
-          if (this._cancelable.is_cancelled()) {
-            break;
-          }
-          console.error(error);
-          this._process_running({ WantRunning: false });
         }
-        await delay(5000);
-      }
-    }
 
-    _parse_response() {
-      if (this._prefs) {
-        this._process_running(this._prefs);
-        this._process_dns(this._prefs);
-        this._process_routes(this._prefs);
-        this._process_lan(this._prefs);
-        this._process_shields(this._prefs);
-        this._process_ssh(this._prefs);
-        this._process_exit_node(this._prefs);
-        if (this._peers) {
-          this._process_nodes(this._prefs, this._peers);
+        _processExitNode(prefs) {
+            const exitNodeId = prefs.ExitNodeID;
+            if (exitNodeId !== this._exitNode) {
+                this._exitNode = exitNodeId;
+                this.notify('exit-node');
+                const exitNodePeer = this._peers.find(peer => peer.ID === exitNodeId);
+                this._exitNodeName = exitNodePeer ? exitNodePeer.DNSName.split('.')[0] : null;
+                this.notify('exit-node-name');
+            }
         }
-      }
-    }
 
-    _update_prefs(prefs) {
-      const body = {
-        ...prefs,
-        ...Object.fromEntries(
-          Object.entries(prefs)
-            .map(([key, _]) => [`${key}set`, true]),
-        ),
-      }
-      this._client.request("PATCH", "/localapi/v0/prefs", body)
-        .then(
-          (prefs) => {
-            this._prefs = prefs;
-            this._parse_response();
-          },
-          (error) => console.error(error),
-        );
-    }
+        _processDns(prefs) {
+            const acceptDns = prefs.CorpDNS;
+            if (acceptDns !== this._dns) {
+                this._dns = acceptDns;
+                this.notify('accept-dns');
+            }
+        }
 
-    _update_profile(value) {
-      this._client.request("POST", `/localapi/v0/profiles/${value}`, {})
+        _processRoutes(prefs) {
+            const acceptRoutes = prefs.RouteAll;
+            if (acceptRoutes !== this._routes) {
+                this._routes = acceptRoutes;
+                this.notify('accept-routes');
+            }
+        }
+
+        _processLan(prefs) {
+            const allowLanAccess = prefs.ExitNodeAllowLANAccess;
+            if (allowLanAccess !== this._allowLanAccess) {
+                this._allowLanAccess = allowLanAccess;
+                this.notify('allow-lan-access');
+            }
+        }
+
+        _processShields(prefs) {
+            const shieldsUp = prefs.ShieldsUp;
+            if (shieldsUp !== this._shields_up) {
+                this._shields_up = shieldsUp;
+                this.notify('shields-up');
+            }
+        }
+
+        _processSsh(prefs) {
+            const ssh = prefs.RunSSH;
+            if (ssh !== this._ssh) {
+                this._ssh = ssh;
+                this.notify('ssh');
+            }
+        }
+
+        get running() {
+            return this._running;
+        }
+
+        set running(value) {
+            if (this.running === value)
+                return;
+
+            this._updatePrefs({WantRunning: value});
+        }
+
+        get accept_dns() {
+            return this._dns;
+        }
+
+        set accept_dns(value) {
+            if (this.accept_dns === value)
+                return;
+
+            this._updatePrefs({CorpDNS: value});
+        }
+
+        get accept_routes() {
+            return this._routes;
+        }
+
+        set accept_routes(value) {
+            if (this.accept_routes === value)
+                return;
+
+            this._updatePrefs({RouteAll: value});
+        }
+
+        get allow_lan_access() {
+            return this._allowLanAccess;
+        }
+
+        set allow_lan_access(value) {
+            if (this.allow_lan_access === value)
+                return;
+
+            this._updatePrefs({ExitNodeAllowLANAccess: value});
+        }
+
+        get shields_up() {
+            return this._shields_up;
+        }
+
+        set shields_up(value) {
+            if (this.shields_up === value)
+                return;
+
+            this._updatePrefs({ShieldsUp: value});
+        }
+
+        get ssh() {
+            return this._ssh;
+        }
+
+        set ssh(value) {
+            if (this.ssh === value)
+                return;
+
+            this._updatePrefs({RunSSH: value});
+        }
+
+        get exit_node() {
+            return this._exitNode;
+        }
+
+        set exit_node(value) {
+            if (this.exit_node === value)
+                return;
+
+            this._updatePrefs({ExitNodeID: value});
+        }
+
+        get exit_node_name() {
+            return this._exitNodeName;
+        }
+
+        get nodes() {
+            return this._nodes;
+        }
+
+        get profiles() {
+            return this._profiles;
+        }
+
+        set profiles(value) {
+            this._updateProfile(value);
+        }
+
+        async _listen() {
+            const delayPromise = delay => new Promise(resolve => {
+                const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
+                    const index = this._timeouts.indexOf(id);
+                    if (index > -1)
+                        this._timeouts.splice(index, 1);
+                    resolve();
+                    return GLib.SOURCE_REMOVE;
+                });
+                this._timeouts.push(id);
+            });
+
+            while (true) {
+                try {
+                    // eslint-disable-next-line no-await-in-loop
+                    const status = await this._client.request('GET', '/localapi/v0/status');
+                    this._peers = Object.values(status.Peer || {});
+                    // eslint-disable-next-line no-await-in-loop
+                    this._prefs = await this._client.request('GET', '/localapi/v0/prefs');
+                    // eslint-disable-next-line no-await-in-loop
+                    this._profiles = await this._client.request('GET', '/localapi/v0/profiles/');
+                    this.notify('profiles');
+                    this._parseResponse();
+
+                    // eslint-disable-next-line no-await-in-loop
+                    for await (const update of this._client.stream('GET', '/localapi/v0/watch-ipn-bus', this._cancelable)) {
+                        let shouldUpdate = false;
+                        if (update.Prefs) {
+                            this._prefs = update.Prefs;
+                            shouldUpdate = true;
+                        }
+                        if (update.NetMap) {
+                            this._peers = update.NetMap.Peers.map(peer => ({
+                                ID: peer.StableID,
+                                DNSName: peer.Name,
+                                OS: peer.Hostinfo.OS,
+                                ExitNodeOption: peer.AllowedIPs?.includes('0.0.0.0/0'),
+                                Online: peer.Online,
+                                TailscaleIPs: peer.Addresses.map(address => address.split('/')[0]),
+                                Tags: peer.Tags,
+                                Location: peer.Hostinfo.Location,
+                            }));
+                            shouldUpdate = true;
+                        }
+                        if (shouldUpdate)
+                            this._parseResponse();
+                    }
+                } catch (error) {
+                    if (this._cancelable.is_cancelled())
+                        break;
+
+                    console.error(error);
+                    this._processRunning({WantRunning: false});
+                }
+                // eslint-disable-next-line no-await-in-loop
+                await delayPromise(5000);
+            }
+        }
+
+        _parseResponse() {
+            if (this._prefs) {
+                this._processRunning(this._prefs);
+                this._processDns(this._prefs);
+                this._processRoutes(this._prefs);
+                this._processLan(this._prefs);
+                this._processShields(this._prefs);
+                this._processSsh(this._prefs);
+                this._processExitNode(this._prefs);
+                if (this._peers)
+                    this._processNodes(this._prefs, this._peers);
+            }
+        }
+
+        _updatePrefs(prefUpdatePartial) {
+            const body = {
+                ...prefUpdatePartial,
+                ...Object.fromEntries(
+                    Object.entries(prefUpdatePartial)
+            .map(([key, _]) => [`${key}set`, true])
+                ),
+            };
+            this._client.request('PATCH', '/localapi/v0/prefs', body)
         .then(
-          () => {
-            this.notify('profiles');
-          },
-          (error) => console.error(error),
+            prefs => {
+                this._prefs = prefs;
+                this._parseResponse();
+            },
+            error => console.error(error)
         );
+        }
+
+        _updateProfile(value) {
+            this._client.request('POST', `/localapi/v0/profiles/${value}`, {})
+        .then(
+            () => {
+                this.notify('profiles');
+            },
+            error => console.error(error)
+        );
+        }
     }
-  }
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "sourceMap": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "target": "ES2023",
+    "lib": [
+      "ES2023"
+    ]
+  },
+  "files": [
+    "tailscale-gnome-qs@tailscale-qs.github.io/extension.js",
+    "tailscale-gnome-qs@tailscale-qs.github.io/tailscale.js",
+    "tailscale-gnome-qs@tailscale-qs.github.io/mullvad.js"
+  ],
+  "include": [
+    "ambient.d.ts"
+  ]
+}


### PR DESCRIPTION
Pulled in linter rules from Gnome Extensions, this way we're consistent with upstream and maintain a reliable style.