### PR TITLE
enhancement: Use the Profile's DisplayName, if available

### DIFF
--- a/tailscale-gnome-qs@tailscale-qs.github.io/extension.js
+++ b/tailscale-gnome-qs@tailscale-qs.github.io/extension.js
@@ -371,7 +371,7 @@ const TailscaleMenuToggle = GObject.registerClass(
           if (!p.NetworkProfile || !p.NetworkProfile.DomainName) continue; // Skip invalid profiles
           let enabled = obj._prefs.ControlURL === p.ControlURL && obj._prefs.Config.UserProfile.ID === p.UserProfile.ID;
           const onClick = () => { tailscale.profiles = p.ID; }
-          profiles.menu.addMenuItem(new TailscaleProfileItem(p.Name, p.NetworkProfile.DomainName, enabled, onClick));
+          profiles.menu.addMenuItem(new TailscaleProfileItem(p.NetworkProfile.DisplayName? p.NetworkProfile.DisplayName : p.Name, p.NetworkProfile.DomainName, enabled, onClick));
         }
       }
       tailscale.connect("notify::profiles", (obj) => update_profiles(obj));


### PR DESCRIPTION
This change will try to use the DisplayName to display the tailscale profiles in the extension.

Result when changed:
<img width="328" height="438" alt="image" src="https://github.com/user-attachments/assets/61ccea05-f578-4f98-a876-44b3e8e50b53" />

