### PR TITLE
chore: Fixup workflows for Releases

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
@@ -21,7 +21,10 @@ jobs:
       run: |
         make build
 
-    - uses: actions/upload-artifact@v4
+    - name: linter
+      uses: reviewdog/action-eslint@2fee6dd72a5419ff4113f694e2068d2a03bb35dd # v1.33.2
       with:
-        name: tailscale-gnome-qs@tailscale-qs.github.zip
-        path: tailscale-gnome-qs@tailscale-qs.github.zip
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        reporter: github-check
+        eslint_flags: "tailscale-gnome-qs@tailscale-qs.github.io/"
+        fail_level: warning

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,46 @@
+name: Release Plugin
 on:
   push:
     tags:
       - 'v*'
-
 jobs:
   package-and-upload:
     name: Package and Upload GNOME Extension
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Cache Apt Packages
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: make gettext gnome-shell
+          version: 1.0
+      - name: Verify linted
+        uses: reviewdog/action-eslint@2fee6dd72a5419ff4113f694e2068d2a03bb35dd # v1.33.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          eslint_flags: "tailscale-gnome-qs@tailscale-qs.github.io/"
+          fail_level: warning
+      - name: Add Version name
+        uses: jossef/action-set-json-field@v2.1
+        with:
+          file: tailscale-gnome-qs@tailscale-qs.github.io/metadata.json
+          field: version-name
+          value: ${{ github.ref_name }}
+      - name: Test extension builds from scratch
+        run: |
+          make build && cd ../
+      - name: Create Release
+        run: gh release create ${{ github.ref_name }} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to Existing Release
+        run: gh release upload ${{ github.ref_name }} tailscale-gnome-qs@tailscale-qs.github.io.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Package and Upload GNOME Extension
         uses: murar8/gnome-extensions-action@aad5516b92eeed1014a06a6e7d47d34c96fd82c5
         with:

--- a/.github/workflows/reviewdog-eslint.yml
+++ b/.github/workflows/reviewdog-eslint.yml
@@ -10,8 +10,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: reviewdog/action-eslint@2fee6dd72a5419ff4113f694e2068d2a03bb35dd # v1.33.2
+      - uses: actions/checkout@v3
+      - uses: reviewdog/action-eslint@v1.34.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UUID = tailscale-gnome-qs@tailscale-qs.github.io
-BUNDLE_PATH = "$(UUID).zip"
-EXTENSION_DIR = "$(UUID)"
+BUNDLE_PATH = $(UUID).zip
+EXTENSION_DIR = $(UUID)
 all: build install
 .PHONY: build install clean
 build:

--- a/tailscale-gnome-qs@tailscale-qs.github.io/metadata.json
+++ b/tailscale-gnome-qs@tailscale-qs.github.io/metadata.json
@@ -11,6 +11,5 @@
     "50"
   ],
   "url": "https://github.com/tailscale-qs/tailscale-gnome-qs",
-  "gettext-domain": "tailscale-gnome-qs@tailscale-qs.github.io",
-  "version": 5
+  "gettext-domain": "tailscale-gnome-qs@tailscale-qs.github.io"
 }


### PR DESCRIPTION
- Remove Version from metadata.json
  * This is applied to GnomeExtensions automatically per [the `version` field](https://gjs.guide/extensions/overview/anatomy.html#version)
- Add linter to all steps
  * This will ensure the js follows expected formatting on branches and releases
- Trigger Release on tag-push
  * This will make it easy to ensure consistency across Gnome-Extensions and zipped artifacts on Github
  * This ensure releases match release notes
  * Attribute `version-name` to the release version
  * Allows auditability of tags to releases for code consistency