### PR TITLE
doc: Add a list of our contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,19 @@
+# Contributors
+
+Thank you so much to our amazing contributors!
+
+
+*  [joaophi](https://github.com/joaophi)
+*  [alexjfinch](https://github.com/alexjfinch)
+*  [aoiwelle](https://github.com/aoiwelle)
+*  [aayushrautela](https://github.com/aayushrautela)
+*  [sydro](https://github.com/sydro)
+*  [abn](https://github.com/abn)
+*  [txelu](https://api.github.com/users/txelu)
+*  [aquacash5](https://github.com/aquacash5)
+*  [sideeffffect](https://github.com/sideeffffect)
+*  [rjocoleman](https://github.com/rjocoleman)
+*  [albanobattistella](https://github.com/albanobattistella)
+*  [matdave](https://github.com/matdave)
+*  [pesader](https://github.com/pesader)
+*  [infopunk](https://github.com/infopunk)


### PR DESCRIPTION
This is tracked in `CONTRIBUTORS.md`. Source:
[https://api.github.com/repos/tailscale-qs/tailscale-gnome-qs/contributors](https://api.github.com/repos/tailscale-qs/tailscale-gnome-qs/contributors)